### PR TITLE
Position legend details against legend item

### DIFF
--- a/src/legacy/ui/public/vis/vis_types/_vislib_vis_legend.scss
+++ b/src/legacy/ui/public/vis/vis_types/_vislib_vis_legend.scss
@@ -2,8 +2,9 @@
 
 // NOTE: Some of the styles attempt to align with the TSVB legend
 
-$colorPickerWidth: $euiSizeM * 10;
-$legendLineHeight: $euiSize;
+$visLegendWidth: 150px;
+$visColorPickerWidth: $euiSizeM * 10;
+$visLegendLineHeight: $euiSize;
 
 .visLegend__toggle {
   border-radius: $euiBorderRadius;
@@ -31,10 +32,9 @@ $legendLineHeight: $euiSize;
   display: flex;
   min-height: 0;
   height: 100%;
-  overflow: hidden;
 }
 
-.visLib--legend-left{
+.visLib--legend-left {
   .visLegend__list {
     margin-bottom: $euiSizeL;
   }
@@ -46,21 +46,32 @@ $legendLineHeight: $euiSize;
   }
 }
 
+/**
+ * 1. Position the .visLegend__valueDetails absolutely against the legend item
+ * 2. Make sure the .visLegend__valueDetails is visible outside the list bounds
+ * 3. Make sure the currently selected item is top most in z level
+ */
+
 .visLegend__list {
   @include euiScrollBar;
-  line-height: $legendLineHeight;
-  width: 150px; // Must be a hard-coded width for the chart to get its correct dimensions
+  display: flex;
+  line-height: $visvisLegendLineHeight;
+  width: $visLegendWidth; // Must be a hard-coded width for the chart to get its correct dimensions
   flex: 1 1 auto;
+  flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
 
   .visLib--legend-top &,
   .visLib--legend-bottom & {
     width: auto;
-    overflow-y: hidden;
+    flex-direction: row;
+    flex-wrap: wrap;
+    overflow: visible; /* 2 */
 
     .visLegend__value {
-      display: inline-block;
+      flex-grow: 0;
+      max-width: $visLegendWidth;
     }
   }
 
@@ -73,9 +84,11 @@ $legendLineHeight: $euiSize;
   cursor: pointer;
   padding: $euiSizeXS;
   display: flex;
+  flex-shrink: 0;
+  position: relative; /* 1 */
 
   > * {
-    max-width: 100%;
+    max-width: 100%; // Needed for truncation (dom element has no class)
   }
 
   &.disabled {
@@ -84,6 +97,7 @@ $legendLineHeight: $euiSize;
 }
 
 .visLegend__valueTitle {
+  @include euiTextTruncate; // ALWAYS truncate
   color: $visTextColor;
 
   &:hover {
@@ -91,14 +105,8 @@ $legendLineHeight: $euiSize;
   }
 }
 
-.visLegend__valueTitle--truncate {
-  @include euiTextTruncate;
-}
-
-.visLegend__valueTitle--full {
-  word-break: break-all;
-  overflow: hidden;
-  min-width: $colorPickerWidth;
+.visLegend__valueTitle--full ~ .visLegend__valueDetails {
+  z-index: 2; /* 3 */
 }
 
 .visLegend__valueDetails {
@@ -110,29 +118,26 @@ $legendLineHeight: $euiSize;
     border-bottom: 1px solid $euiColorLightShade;
   }
 
-
-  .visLib--legend-top & {
-    position: absolute;
-    margin-top: $euiSizeXS;
+  .visLib--legend-top &,
+  .visLib--legend-bottom & {
+    @include euiBottomShadowMedium;
+    position: absolute; /* 1 */
+    border-radius: $euiBorderRadius;
   }
 
   .visLib--legend-bottom & {
-    position: absolute;
-    margin-bottom: 2 * $euiSizeXS;
-    bottom: $legendLineHeight;
+    bottom: $visLegendLineHeight + $euiSizeXS;
   }
-
 }
 
 .visLegend__valueColorPicker {
-  $colorPickerDotsPerRow: 8;
-
-  width: $colorPickerWidth;
+  width: $visColorPickerWidth;
   margin: auto;
 
   .visLegend__valueColorPickerDot {
+    $colorPickerDotsPerRow: 8;
     $colorPickerDotMargin: $euiSizeXS / 2;
-    $colorPickerDotWidth: $colorPickerWidth / $colorPickerDotsPerRow - 2 * $colorPickerDotMargin;
+    $colorPickerDotWidth: $visColorPickerWidth / $colorPickerDotsPerRow - 2 * $colorPickerDotMargin;
 
     margin: $colorPickerDotMargin;
     width: $colorPickerDotWidth;

--- a/src/legacy/ui/public/vis/vis_types/_vislib_vis_legend.scss
+++ b/src/legacy/ui/public/vis/vis_types/_vislib_vis_legend.scss
@@ -2,6 +2,10 @@
 
 // NOTE: Some of the styles attempt to align with the TSVB legend
 
+$visLegendWidth: 150px;
+$visColorPickerWidth: $euiSizeM * 10;
+$visLegendLineHeight: $euiSize;
+
 .visLegend__toggle {
   border-radius: $euiBorderRadius;
   position: absolute;
@@ -28,10 +32,9 @@
   display: flex;
   min-height: 0;
   height: 100%;
-  overflow: hidden;
 }
 
-.visLib--legend-left{
+.visLib--legend-left {
   .visLegend__list {
     margin-bottom: $euiSizeL;
   }
@@ -43,21 +46,32 @@
   }
 }
 
+/**
+ * 1. Position the .visLegend__valueDetails absolutely against the legend item
+ * 2. Make sure the .visLegend__valueDetails is visible outside the list bounds
+ * 3. Make sure the currently selected item is top most in z level
+ */
+
 .visLegend__list {
   @include euiScrollBar;
-  line-height: $euiSize;
-  width: 150px; // Must be a hard-coded width for the chart to get its correct dimensions
+  display: flex;
+  line-height: $visvisLegendLineHeight;
+  width: $visLegendWidth; // Must be a hard-coded width for the chart to get its correct dimensions
   flex: 1 1 auto;
+  flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
 
   .visLib--legend-top &,
   .visLib--legend-bottom & {
     width: auto;
-    overflow-y: hidden;
+    flex-direction: row;
+    flex-wrap: wrap;
+    overflow: visible; /* 2 */
 
     .visLegend__value {
-      display: inline-block;
+      flex-grow: 0;
+      max-width: $visLegendWidth;
     }
   }
 
@@ -70,9 +84,11 @@
   cursor: pointer;
   padding: $euiSizeXS;
   display: flex;
+  flex-shrink: 0;
+  position: relative; /* 1 */
 
   > * {
-    max-width: 100%;
+    max-width: 100%; // Needed for truncation (dom element has no class)
   }
 
   &.disabled {
@@ -81,6 +97,7 @@
 }
 
 .visLegend__valueTitle {
+  @include euiTextTruncate; // ALWAYS truncate
   color: $visTextColor;
 
   &:hover {
@@ -88,25 +105,42 @@
   }
 }
 
-.visLegend__valueTitle--truncate {
-  @include euiTextTruncate;
-}
-
-.visLegend__valueTitle--full {
-  word-break: break-all;
+.visLegend__valueTitle--full ~ .visLegend__valueDetails {
+  z-index: 2; /* 3 */
 }
 
 .visLegend__valueDetails {
-  border-bottom: 1px solid $euiColorLightShade;
-  padding-bottom: $euiSizeXS;
+  background-color: $euiColorEmptyShade;
+
+  .visLib--legend-left &,
+  .visLib--legend-right & {
+    margin-top: $euiSizeXS;
+    border-bottom: 1px solid $euiColorLightShade;
+  }
+
+  .visLib--legend-top &,
+  .visLib--legend-bottom & {
+    @include euiBottomShadowMedium;
+    position: absolute; /* 1 */
+    border-radius: $euiBorderRadius;
+  }
+
+  .visLib--legend-bottom & {
+    bottom: $visLegendLineHeight + $euiSizeXS;
+  }
 }
 
 .visLegend__valueColorPicker {
-  width: $euiSizeM * 10;
+  width: $visColorPickerWidth;
   margin: auto;
 
   .visLegend__valueColorPickerDot {
-    margin: $euiSizeXS / 2;
+    $colorPickerDotsPerRow: 8;
+    $colorPickerDotMargin: $euiSizeXS / 2;
+    $colorPickerDotWidth: $visColorPickerWidth / $colorPickerDotsPerRow - 2 * $colorPickerDotMargin;
+
+    margin: $colorPickerDotMargin;
+    width: $colorPickerDotWidth;
 
     &:hover {
       transform: scale(1.4);

--- a/src/legacy/ui/public/vis/vis_types/_vislib_vis_legend.scss
+++ b/src/legacy/ui/public/vis/vis_types/_vislib_vis_legend.scss
@@ -2,10 +2,6 @@
 
 // NOTE: Some of the styles attempt to align with the TSVB legend
 
-$visLegendWidth: 150px;
-$visColorPickerWidth: $euiSizeM * 10;
-$visLegendLineHeight: $euiSize;
-
 .visLegend__toggle {
   border-radius: $euiBorderRadius;
   position: absolute;
@@ -32,9 +28,10 @@ $visLegendLineHeight: $euiSize;
   display: flex;
   min-height: 0;
   height: 100%;
+  overflow: hidden;
 }
 
-.visLib--legend-left {
+.visLib--legend-left{
   .visLegend__list {
     margin-bottom: $euiSizeL;
   }
@@ -46,32 +43,21 @@ $visLegendLineHeight: $euiSize;
   }
 }
 
-/**
- * 1. Position the .visLegend__valueDetails absolutely against the legend item
- * 2. Make sure the .visLegend__valueDetails is visible outside the list bounds
- * 3. Make sure the currently selected item is top most in z level
- */
-
 .visLegend__list {
   @include euiScrollBar;
-  display: flex;
-  line-height: $visvisLegendLineHeight;
-  width: $visLegendWidth; // Must be a hard-coded width for the chart to get its correct dimensions
+  line-height: $euiSize;
+  width: 150px; // Must be a hard-coded width for the chart to get its correct dimensions
   flex: 1 1 auto;
-  flex-direction: column;
   overflow-x: hidden;
   overflow-y: auto;
 
   .visLib--legend-top &,
   .visLib--legend-bottom & {
     width: auto;
-    flex-direction: row;
-    flex-wrap: wrap;
-    overflow: visible; /* 2 */
+    overflow-y: hidden;
 
     .visLegend__value {
-      flex-grow: 0;
-      max-width: $visLegendWidth;
+      display: inline-block;
     }
   }
 
@@ -84,11 +70,9 @@ $visLegendLineHeight: $euiSize;
   cursor: pointer;
   padding: $euiSizeXS;
   display: flex;
-  flex-shrink: 0;
-  position: relative; /* 1 */
 
   > * {
-    max-width: 100%; // Needed for truncation (dom element has no class)
+    max-width: 100%;
   }
 
   &.disabled {
@@ -97,7 +81,6 @@ $visLegendLineHeight: $euiSize;
 }
 
 .visLegend__valueTitle {
-  @include euiTextTruncate; // ALWAYS truncate
   color: $visTextColor;
 
   &:hover {
@@ -105,42 +88,25 @@ $visLegendLineHeight: $euiSize;
   }
 }
 
-.visLegend__valueTitle--full ~ .visLegend__valueDetails {
-  z-index: 2; /* 3 */
+.visLegend__valueTitle--truncate {
+  @include euiTextTruncate;
+}
+
+.visLegend__valueTitle--full {
+  word-break: break-all;
 }
 
 .visLegend__valueDetails {
-  background-color: $euiColorEmptyShade;
-
-  .visLib--legend-left &,
-  .visLib--legend-right & {
-    margin-top: $euiSizeXS;
-    border-bottom: 1px solid $euiColorLightShade;
-  }
-
-  .visLib--legend-top &,
-  .visLib--legend-bottom & {
-    @include euiBottomShadowMedium;
-    position: absolute; /* 1 */
-    border-radius: $euiBorderRadius;
-  }
-
-  .visLib--legend-bottom & {
-    bottom: $visLegendLineHeight + $euiSizeXS;
-  }
+  border-bottom: 1px solid $euiColorLightShade;
+  padding-bottom: $euiSizeXS;
 }
 
 .visLegend__valueColorPicker {
-  width: $visColorPickerWidth;
+  width: $euiSizeM * 10;
   margin: auto;
 
   .visLegend__valueColorPickerDot {
-    $colorPickerDotsPerRow: 8;
-    $colorPickerDotMargin: $euiSizeXS / 2;
-    $colorPickerDotWidth: $visColorPickerWidth / $colorPickerDotsPerRow - 2 * $colorPickerDotMargin;
-
-    margin: $colorPickerDotMargin;
-    width: $colorPickerDotWidth;
+    margin: $euiSizeXS / 2;
 
     &:hover {
       transform: scale(1.4);


### PR DESCRIPTION
@flash1293 I did a quick PR for you against yours to better position the details when absolute positioned.

Here's a video of it working: https://d.pr/free/v/xcuMUc

The only issue I run into is if the legend item's width is smaller than the details width and very close to the right edge, the details pane can get cut off (but this feels like rare edge case).

<img src="https://d.pr/free/i/LCYMmG+" width="50%" />