### PR TITLE
Removing EuiCodeEditor from EuiPanel

### DIFF
--- a/x-pack/legacy/plugins/grokdebugger/public/components/custom_patterns_input/custom_patterns_input.js
+++ b/x-pack/legacy/plugins/grokdebugger/public/components/custom_patterns_input/custom_patterns_input.js
@@ -10,9 +10,8 @@ import {
   EuiCallOut,
   EuiCodeBlock,
   EuiFormRow,
-  EuiPanel,
   EuiCodeEditor,
-  EuiSpacer
+  EuiSpacer,
 } from '@elastic/eui';
 import { EDITOR } from '../../../common/constants';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -24,49 +23,41 @@ MSG message-id=<%{GREEDYDATA}>`;
   return (
     <EuiAccordion
       id="customPatternsInput"
-      buttonContent={(
+      buttonContent={
         <FormattedMessage
           id="xpack.grokDebugger.customPatternsButtonLabel"
           defaultMessage="Custom Patterns"
         />
-      )}
+      }
       data-test-subj="btnToggleCustomPatternsInput"
     >
-
       <EuiSpacer size="m" />
 
       <EuiCallOut
-        title={(
+        title={
           <FormattedMessage
             id="xpack.grokDebugger.customPatterns.callOutTitle"
             defaultMessage="Enter one custom pattern per line. For example:"
           />
-        )}
+        }
       >
-        <EuiCodeBlock>
-          { sampleCustomPatterns }
-        </EuiCodeBlock>
+        <EuiCodeBlock>{sampleCustomPatterns}</EuiCodeBlock>
       </EuiCallOut>
 
       <EuiSpacer size="m" />
 
-      <EuiFormRow
-        fullWidth
-        data-test-subj="aceCustomPatternsInput"
-      >
-        <EuiPanel paddingSize="s">
-          <EuiCodeEditor
-            width="100%"
-            value={value}
-            onChange={onChange}
-            setOptions={{
-              highlightActiveLine: false,
-              highlightGutterLine: false,
-              minLines: EDITOR.PATTERN_MIN_LINES,
-              maxLines: EDITOR.PATTERN_MAX_LINES,
-            }}
-          />
-        </EuiPanel>
+      <EuiFormRow fullWidth data-test-subj="aceCustomPatternsInput">
+        <EuiCodeEditor
+          width="100%"
+          value={value}
+          onChange={onChange}
+          setOptions={{
+            highlightActiveLine: false,
+            highlightGutterLine: false,
+            minLines: EDITOR.PATTERN_MIN_LINES,
+            maxLines: EDITOR.PATTERN_MAX_LINES,
+          }}
+        />
       </EuiFormRow>
     </EuiAccordion>
   );

--- a/x-pack/legacy/plugins/grokdebugger/public/components/event_input/event_input.js
+++ b/x-pack/legacy/plugins/grokdebugger/public/components/event_input/event_input.js
@@ -5,39 +5,30 @@
  */
 
 import React from 'react';
-import {
-  EuiFormRow,
-  EuiPanel,
-  EuiCodeEditor
-} from '@elastic/eui';
+import { EuiFormRow, EuiCodeEditor } from '@elastic/eui';
 import { EDITOR } from '../../../common/constants';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 export function EventInput({ value, onChange }) {
   return (
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="xpack.grokDebugger.sampleDataLabel"
-          defaultMessage="Sample Data"
-        />
-      )}
+      label={
+        <FormattedMessage id="xpack.grokDebugger.sampleDataLabel" defaultMessage="Sample Data" />
+      }
       fullWidth
       data-test-subj="aceEventInput"
     >
-      <EuiPanel paddingSize="s">
-        <EuiCodeEditor
-          width="100%"
-          value={value}
-          onChange={onChange}
-          setOptions={{
-            highlightActiveLine: false,
-            highlightGutterLine: false,
-            minLines: EDITOR.SAMPLE_DATA_MIN_LINES,
-            maxLines: EDITOR.SAMPLE_DATA_MAX_LINES
-          }}
-        />
-      </EuiPanel>
+      <EuiCodeEditor
+        width="100%"
+        value={value}
+        onChange={onChange}
+        setOptions={{
+          highlightActiveLine: false,
+          highlightGutterLine: false,
+          minLines: EDITOR.SAMPLE_DATA_MIN_LINES,
+          maxLines: EDITOR.SAMPLE_DATA_MAX_LINES,
+        }}
+      />
     </EuiFormRow>
   );
 }

--- a/x-pack/legacy/plugins/grokdebugger/public/components/event_output/event_output.js
+++ b/x-pack/legacy/plugins/grokdebugger/public/components/event_output/event_output.js
@@ -5,38 +5,32 @@
  */
 
 import React from 'react';
-import {
-  EuiFormRow,
-  EuiPanel,
-  EuiCodeEditor
-} from '@elastic/eui';
+import { EuiFormRow, EuiCodeEditor } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 export function EventOutput({ value }) {
   return (
     <EuiFormRow
-      label={(
+      label={
         <FormattedMessage
           id="xpack.grokDebugger.structuredDataLabel"
           defaultMessage="Structured Data"
         />
-      )}
+      }
       fullWidth
       data-test-subj="aceEventOutput"
     >
-      <EuiPanel paddingSize="s">
-        <EuiCodeEditor
-          mode="json"
-          isReadOnly
-          width="100%"
-          height="340px"
-          value={JSON.stringify(value, null, 2)}
-          setOptions={{
-            highlightActiveLine: false,
-            highlightGutterLine: false,
-          }}
-        />
-      </EuiPanel>
+      <EuiCodeEditor
+        mode="json"
+        isReadOnly
+        width="100%"
+        height="340px"
+        value={JSON.stringify(value, null, 2)}
+        setOptions={{
+          highlightActiveLine: false,
+          highlightGutterLine: false,
+        }}
+      />
     </EuiFormRow>
   );
 }

--- a/x-pack/legacy/plugins/grokdebugger/public/components/pattern_input/pattern_input.js
+++ b/x-pack/legacy/plugins/grokdebugger/public/components/pattern_input/pattern_input.js
@@ -5,11 +5,7 @@
  */
 
 import React from 'react';
-import {
-  EuiFormRow,
-  EuiPanel,
-  EuiCodeEditor
-} from '@elastic/eui';
+import { EuiFormRow, EuiCodeEditor } from '@elastic/eui';
 import { EDITOR } from '../../../common/constants';
 import { GrokMode } from '../../lib/ace';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -17,29 +13,24 @@ import { FormattedMessage } from '@kbn/i18n/react';
 export function PatternInput({ value, onChange }) {
   return (
     <EuiFormRow
-      label={(
-        <FormattedMessage
-          id="xpack.grokDebugger.grokPatternLabel"
-          defaultMessage="Grok Pattern"
-        />
-      )}
+      label={
+        <FormattedMessage id="xpack.grokDebugger.grokPatternLabel" defaultMessage="Grok Pattern" />
+      }
       fullWidth
       data-test-subj="acePatternInput"
     >
-      <EuiPanel paddingSize="s">
-        <EuiCodeEditor
-          width="100%"
-          value={value}
-          onChange={onChange}
-          mode={new GrokMode()}
-          setOptions={{
-            highlightActiveLine: false,
-            highlightGutterLine: false,
-            minLines: EDITOR.PATTERN_MIN_LINES,
-            maxLines: EDITOR.PATTERN_MAX_LINES,
-          }}
-        />
-      </EuiPanel>
+      <EuiCodeEditor
+        width="100%"
+        value={value}
+        onChange={onChange}
+        mode={new GrokMode()}
+        setOptions={{
+          highlightActiveLine: false,
+          highlightGutterLine: false,
+          minLines: EDITOR.PATTERN_MIN_LINES,
+          maxLines: EDITOR.PATTERN_MAX_LINES,
+        }}
+      />
     </EuiFormRow>
   );
 }


### PR DESCRIPTION
## Summary

I just removed the `EuiPanel` wrapping all `EuiCodeEditor`. This way we're avoiding having cards insides cards.

![dev-tools-grok-debugger](https://user-images.githubusercontent.com/2750668/68784219-22cabf00-0634-11ea-9e35-b08247e90ce1.jpg)
