### PR TITLE
Design border changes

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.scss
@@ -114,6 +114,14 @@
   right: 0;
 }
 
+.lnsLayerPanel__palette {
+  border-radius: 0 0 ($euiBorderRadius - 1px) ($euiBorderRadius - 1px);
+
+  &::after {
+    border: none;
+  }
+}
+
 .lnsLayerPanel__dimensionLink {
   width: 100%;
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/palette_indicator.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/palette_indicator.tsx
@@ -12,7 +12,11 @@ export function PaletteIndicator({ accessorConfig }: { accessorConfig: AccessorC
   if (accessorConfig.triggerIcon !== 'colorBy' || !accessorConfig.palette) return null;
   return (
     <div className="lnsLayerPanel__paletteContainer">
-      <EuiColorPaletteDisplay size="xs" palette={accessorConfig.palette} />
+      <EuiColorPaletteDisplay
+        className="lnsLayerPanel__palette"
+        size="xs"
+        palette={accessorConfig.palette}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds the slight design changes Michael asks for here https://github.com/elastic/kibana/pull/85239#discussion_r538847922:

before:
<img width="274" alt="Screenshot 2020-12-09 at 14 02 31" src="https://user-images.githubusercontent.com/4283304/101633173-30b16600-3a27-11eb-9bf5-16080387557c.png">

after:
<img width="290" alt="Screenshot 2020-12-09 at 14 02 04" src="https://user-images.githubusercontent.com/4283304/101633129-21321d00-3a27-11eb-8a66-a3d1c347773d.png">
