### PR TITLE
[Streams] Show field descriptions in ESQL editor and Discover sidebar

### DIFF
--- a/src/platform/packages/shared/kbn-esql-types/src/editor_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/editor_types.ts
@@ -73,7 +73,15 @@ export type EsqlFieldType = (typeof esqlFieldTypes)[number];
  *  Partial fields metadata client, used to avoid circular dependency with @kbn/monaco
  **/
 export interface PartialFieldsMetadataClient {
-  find: ({ fieldNames, attributes }: { fieldNames?: string[]; attributes: string[] }) => Promise<{
+  find: ({
+    fieldNames,
+    attributes,
+    streamName,
+  }: {
+    fieldNames?: string[];
+    attributes: string[];
+    streamName?: string;
+  }) => Promise<{
     fields: Record<
       string,
       {

--- a/src/platform/packages/shared/kbn-field-utils/src/components/field_description/field_description.test.tsx
+++ b/src/platform/packages/shared/kbn-field-utils/src/components/field_description/field_description.test.tsx
@@ -137,6 +137,34 @@ describe('FieldDescription', () => {
     expect(fieldsMetadataService.useFieldsMetadata).toHaveBeenCalledWith({
       attributes: ['description', 'type'],
       fieldNames: ['bytes'],
+      streamName: undefined,
+    });
+  });
+
+  it('should pass streamName to useFieldsMetadata for stream-specific descriptions', async () => {
+    const fieldsMetadataService: Partial<FieldsMetadataPublicStart> = {
+      useFieldsMetadata: jest.fn(() => ({
+        fieldsMetadata: {
+          message: { description: 'Stream-specific description', type: 'keyword' },
+        },
+        loading: false,
+        error: undefined,
+        reload: jest.fn(),
+      })),
+    };
+    render(
+      <FieldDescription
+        field={{ name: 'message', type: 'string', customDescription: undefined }}
+        fieldsMetadataService={fieldsMetadataService as FieldsMetadataPublicStart}
+        streamName="logs.nginx"
+      />
+    );
+    const desc = screen.queryByTestId('fieldDescription-message');
+    expect(desc).toHaveTextContent('Stream-specific description');
+    expect(fieldsMetadataService.useFieldsMetadata).toHaveBeenCalledWith({
+      attributes: ['description', 'type'],
+      fieldNames: ['message'],
+      streamName: 'logs.nginx',
     });
   });
 
@@ -181,6 +209,7 @@ describe('FieldDescription', () => {
     expect(fieldsMetadataService.useFieldsMetadata).toHaveBeenCalledWith({
       attributes: ['description', 'type'],
       fieldNames: ['extension'],
+      streamName: undefined,
     });
   });
 });

--- a/src/platform/packages/shared/kbn-field-utils/src/components/field_description/field_description.tsx
+++ b/src/platform/packages/shared/kbn-field-utils/src/components/field_description/field_description.tsx
@@ -45,14 +45,25 @@ export interface FieldDescriptionContentProps {
 
 export interface FieldDescriptionProps extends FieldDescriptionContentProps {
   fieldsMetadataService?: FieldsMetadataPublicStart;
+  /**
+   * Optional stream name to fetch stream-specific field descriptions (e.g., from Streams plugin)
+   */
+  streamName?: string;
 }
 
 export const FieldDescription: React.FC<FieldDescriptionProps> = ({
   fieldsMetadataService,
+  streamName,
   ...props
 }) => {
   if (fieldsMetadataService && !props.field.customDescription) {
-    return <EcsFieldDescriptionFallback fieldsMetadataService={fieldsMetadataService} {...props} />;
+    return (
+      <EcsFieldDescriptionFallback
+        fieldsMetadataService={fieldsMetadataService}
+        streamName={streamName}
+        {...props}
+      />
+    );
   }
 
   return <FieldDescriptionContent {...props} />;
@@ -60,23 +71,24 @@ export const FieldDescription: React.FC<FieldDescriptionProps> = ({
 
 const EcsFieldDescriptionFallback: React.FC<
   FieldDescriptionProps & { fieldsMetadataService: FieldsMetadataPublicStart }
-> = ({ fieldsMetadataService, ...props }) => {
+> = ({ fieldsMetadataService, streamName, ...props }) => {
   const fieldName = removeKeywordSuffix(props.field.name);
   const { fieldsMetadata, loading } = fieldsMetadataService.useFieldsMetadata({
     attributes: ['description', 'type'],
     fieldNames: [fieldName],
+    streamName,
   });
 
-  const escFieldDescription = fieldsMetadata?.[fieldName]?.description;
-  const escFieldType = fieldsMetadata?.[fieldName]?.type;
+  const fieldDescription = fieldsMetadata?.[fieldName]?.description;
+  const fieldType = fieldsMetadata?.[fieldName]?.type;
 
   return (
     <EuiSkeletonText isLoading={loading} size="s">
       <FieldDescriptionContent
         {...props}
         ecsFieldDescription={
-          escFieldType && esFieldTypeToKibanaFieldType(escFieldType) === props.field.type
-            ? escFieldDescription
+          fieldType && esFieldTypeToKibanaFieldType(fieldType) === props.field.type
+            ? fieldDescription
             : undefined
         }
       />

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.test.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.test.ts
@@ -10,13 +10,54 @@
 import type { PartialFieldsMetadataClient } from '@kbn/esql-types';
 import { getHoverItem, suggest } from '@kbn/esql-language';
 import { monaco } from '../../monaco_imports';
-import { ESQLLang, type ESQLDependencies } from './language';
+import { ESQLLang, extractSourceFromQuery, type ESQLDependencies } from './language';
 
 // Mock the getHoverItem and suggest functions
 jest.mock('@kbn/esql-language', () => ({
   getHoverItem: jest.fn(),
   suggest: jest.fn(),
 }));
+
+describe('extractSourceFromQuery', () => {
+  it('should extract source name from simple FROM clause', () => {
+    expect(extractSourceFromQuery('FROM logs')).toBe('logs');
+    expect(extractSourceFromQuery('FROM logs | WHERE true')).toBe('logs');
+    expect(extractSourceFromQuery('from logs | LIMIT 10')).toBe('logs');
+  });
+
+  it('should extract dotted stream names', () => {
+    expect(extractSourceFromQuery('FROM logs.nginx')).toBe('logs.nginx');
+    expect(extractSourceFromQuery('FROM logs.nginx.access | STATS count()')).toBe(
+      'logs.nginx.access'
+    );
+  });
+
+  it('should return only the first source for multiple sources', () => {
+    expect(extractSourceFromQuery('FROM logs, metrics | STATS count()')).toBe('logs');
+  });
+
+  it('should handle wildcard patterns', () => {
+    expect(extractSourceFromQuery('FROM logs*')).toBe('logs*');
+    expect(extractSourceFromQuery('FROM logs-*')).toBe('logs-*');
+  });
+
+  it('should handle underscores and hyphens in names', () => {
+    expect(extractSourceFromQuery('FROM my_logs')).toBe('my_logs');
+    expect(extractSourceFromQuery('FROM my-logs-2024')).toBe('my-logs-2024');
+  });
+
+  it('should return undefined for queries without FROM clause', () => {
+    expect(extractSourceFromQuery('')).toBeUndefined();
+    expect(extractSourceFromQuery('SHOW INFO')).toBeUndefined();
+    expect(extractSourceFromQuery('ROW x = 1')).toBeUndefined();
+  });
+
+  it('should be case insensitive for FROM keyword', () => {
+    expect(extractSourceFromQuery('FROM logs')).toBe('logs');
+    expect(extractSourceFromQuery('from logs')).toBe('logs');
+    expect(extractSourceFromQuery('From logs')).toBe('logs');
+  });
+});
 
 describe('ESQLLang', () => {
   describe('getSuggestionProvider', () => {
@@ -107,6 +148,7 @@ describe('ESQLLang', () => {
           getFieldsMetadata: mockGetFieldsMetadata,
         });
 
+        // For non-field items, we should not call find at all (early return)
         const notFieldItem: monaco.languages.CompletionItem = {
           label: 'CASE',
           kind: 1,
@@ -118,10 +160,11 @@ describe('ESQLLang', () => {
           notFieldItem,
           {} as any
         );
-        expect(mockFind).toBeCalledTimes(1);
+        expect(mockFind).toBeCalledTimes(0);
         expect(notFieldResolvedItem).toEqual(notFieldItem);
 
         mockFind.mockClear();
+        // For field items that aren't in ECS/streams, we call find once to check ECS list
         const notECSFieldItem: monaco.languages.CompletionItem = {
           label: 'not.ecs.field',
           kind: 4,
@@ -134,6 +177,144 @@ describe('ESQLLang', () => {
         );
         expect(mockFind).toBeCalledTimes(1);
         expect(notECSFieldResolvedItem).toEqual(notECSFieldItem);
+      });
+
+      it('should resolve field descriptions from stream when streamName is in FROM clause', async () => {
+        const mockFind = jest.fn().mockImplementation(async (params) => {
+          // Return stream-specific description when streamName is provided
+          if (params.streamName === 'logs.nginx') {
+            return {
+              fields: {
+                message: {
+                  type: 'keyword',
+                  source: 'streams',
+                  description: 'Stream-specific message description',
+                },
+              },
+            };
+          }
+          // Return empty for ECS list check
+          return { fields: {} };
+        });
+
+        const mockGetFieldsMetadata: Promise<PartialFieldsMetadataClient> = Promise.resolve({
+          find: mockFind,
+        });
+
+        // Mock suggest to simulate provideCompletionItems being called first
+        const mockSuggest = suggest as jest.MockedFunction<typeof suggest>;
+        mockSuggest.mockResolvedValue([]);
+
+        const suggestionProvider = ESQLLang.getSuggestionProvider({
+          getFieldsMetadata: mockGetFieldsMetadata,
+        });
+
+        // First, simulate calling provideCompletionItems to set the lastQueryText
+        const mockModel = {
+          getValue: jest.fn().mockReturnValue('FROM logs.nginx | WHERE message = "test"'),
+        } as unknown as monaco.editor.ITextModel;
+        await suggestionProvider.provideCompletionItems(
+          mockModel,
+          new monaco.Position(1, 40),
+          {} as monaco.languages.CompletionContext,
+          {} as monaco.CancellationToken
+        );
+
+        // Now resolve a field completion item
+        const fieldItem: monaco.languages.CompletionItem = {
+          label: 'message',
+          kind: 4,
+          insertText: 'message',
+          range: new monaco.Range(0, 0, 0, 0),
+        };
+
+        const resolvedItem = await suggestionProvider.resolveCompletionItem!(fieldItem, {} as any);
+
+        // Should fetch from streams with the stream name
+        expect(mockFind).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fieldNames: ['message'],
+            attributes: ['description'],
+            streamName: 'logs.nginx',
+          })
+        );
+
+        // Should have the stream-specific description
+        expect(resolvedItem).toEqual({
+          ...fieldItem,
+          documentation: {
+            value: 'Stream-specific message description',
+          },
+        });
+      });
+
+      it('should fall back to ECS when stream has no description for field', async () => {
+        const mockFind = jest.fn().mockImplementation(async (params) => {
+          // Stream has no description for this field
+          if (params.streamName === 'logs') {
+            return { fields: {} };
+          }
+          // ECS list check - return the field
+          if (params.attributes?.includes('type') && !params.fieldNames) {
+            return {
+              fields: {
+                '@timestamp': { type: 'date', source: 'ecs' },
+              },
+            };
+          }
+          // ECS description lookup
+          if (params.fieldNames?.includes('@timestamp')) {
+            return {
+              fields: {
+                '@timestamp': {
+                  type: 'date',
+                  source: 'ecs',
+                  description: 'ECS timestamp description',
+                },
+              },
+            };
+          }
+          return { fields: {} };
+        });
+
+        const mockGetFieldsMetadata: Promise<PartialFieldsMetadataClient> = Promise.resolve({
+          find: mockFind,
+        });
+
+        const mockSuggest = suggest as jest.MockedFunction<typeof suggest>;
+        mockSuggest.mockResolvedValue([]);
+
+        const suggestionProvider = ESQLLang.getSuggestionProvider({
+          getFieldsMetadata: mockGetFieldsMetadata,
+        });
+
+        // Set up the query context
+        const mockModel = {
+          getValue: jest.fn().mockReturnValue('FROM logs | WHERE @timestamp > now()'),
+        } as unknown as monaco.editor.ITextModel;
+        await suggestionProvider.provideCompletionItems(
+          mockModel,
+          new monaco.Position(1, 35),
+          {} as monaco.languages.CompletionContext,
+          {} as monaco.CancellationToken
+        );
+
+        const fieldItem: monaco.languages.CompletionItem = {
+          label: '@timestamp',
+          kind: 4,
+          insertText: '@timestamp',
+          range: new monaco.Range(0, 0, 0, 0),
+        };
+
+        const resolvedItem = await suggestionProvider.resolveCompletionItem!(fieldItem, {} as any);
+
+        // Should have fallen back to ECS description
+        expect(resolvedItem).toEqual({
+          ...fieldItem,
+          documentation: {
+            value: 'ECS timestamp description',
+          },
+        });
       });
 
       it('should call onSuggestionsWithCustomCommandShown when suggestions contain custom commands', async () => {

--- a/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
+++ b/src/platform/packages/shared/kbn-monaco/src/languages/esql/language.ts
@@ -34,6 +34,30 @@ const removeKeywordSuffix = (name: string) => {
   return name.endsWith('.keyword') ? name.slice(0, -8) : name;
 };
 
+/**
+ * Extracts the first source name from the FROM clause of an ES|QL query.
+ * This is used to determine if we're querying from a stream and to fetch
+ * stream-specific field metadata.
+ *
+ * Examples:
+ * - "FROM logs | WHERE ..." -> "logs"
+ * - "FROM logs.nginx | STATS ..." -> "logs.nginx"
+ * - "FROM logs, metrics | ..." -> "logs" (first source only)
+ * - "FROM logs* | ..." -> "logs*" (wildcard patterns are returned as-is)
+ *
+ * Returns undefined if no FROM clause is found.
+ */
+export const extractSourceFromQuery = (query: string): string | undefined => {
+  // Match FROM clause followed by source name(s)
+  // Source names can contain letters, numbers, dots, underscores, hyphens, and wildcards
+  // The source name ends at whitespace, comma, pipe, or end of string
+  const fromMatch = query.match(/\bFROM\s+([a-zA-Z0-9_.*-]+)/i);
+  if (fromMatch && fromMatch[1]) {
+    return fromMatch[1];
+  }
+  return undefined;
+};
+
 export const ESQL_AUTOCOMPLETE_TRIGGER_CHARS = ['(', ' ', '[', '?'];
 
 export type MonacoMessage = monaco.editor.IMarkerData & {
@@ -151,6 +175,10 @@ export const ESQLLang: CustomLangModuleType<ESQLDependencies, MonacoMessage> = {
     return provider;
   },
   getSuggestionProvider: (deps?: ESQLDependencies): monaco.languages.CompletionItemProvider => {
+    // Store the last query text so resolveCompletionItem can access it
+    // to extract the stream name from the FROM clause
+    let lastQueryText = '';
+
     return {
       triggerCharacters: ESQL_AUTOCOMPLETE_TRIGGER_CHARS,
       async provideCompletionItems(
@@ -158,6 +186,7 @@ export const ESQLLang: CustomLangModuleType<ESQLDependencies, MonacoMessage> = {
         position: monaco.Position
       ): Promise<monaco.languages.CompletionList> {
         const fullText = model.getValue();
+        lastQueryText = fullText;
         const offset = monacoPositionToOffset(fullText, position);
 
         const computeStart = performance.now();
@@ -184,19 +213,41 @@ export const ESQLLang: CustomLangModuleType<ESQLDependencies, MonacoMessage> = {
         if (!deps?.getFieldsMetadata) return item;
         const fieldsMetadataClient = await deps?.getFieldsMetadata;
 
-        const fullEcsMetadataList = await fieldsMetadataClient?.find({
-          attributes: ['type'],
-        });
-        if (!fullEcsMetadataList || !fieldsMetadataClient || typeof item.label !== 'string')
-          return item;
+        if (!fieldsMetadataClient || typeof item.label !== 'string') return item;
+
+        // Only fetch metadata for field suggestions
+        if (item.kind !== monaco.languages.CompletionItemKind.Variable) return item;
 
         const strippedFieldName = removeKeywordSuffix(item.label);
-        if (
-          // If item is not a field, no need to fetch metadata
-          item.kind === monaco.languages.CompletionItemKind.Variable &&
-          // If not ECS, no need to fetch description
-          Object.hasOwn(fullEcsMetadataList?.fields, strippedFieldName)
-        ) {
+
+        // Extract stream name from the FROM clause to fetch stream-specific field descriptions
+        const streamName = extractSourceFromQuery(lastQueryText);
+
+        // Try to fetch stream-specific field metadata first (if querying from a stream)
+        if (streamName) {
+          const streamMetadata = await fieldsMetadataClient.find({
+            fieldNames: [strippedFieldName],
+            attributes: ['description'],
+            streamName,
+          });
+
+          const streamFieldMetadata = streamMetadata.fields[strippedFieldName];
+          if (streamFieldMetadata && streamFieldMetadata.description) {
+            return {
+              ...item,
+              documentation: {
+                value: streamFieldMetadata.description,
+              },
+            };
+          }
+        }
+
+        // Fall back to ECS metadata if no stream-specific description found
+        const fullEcsMetadataList = await fieldsMetadataClient.find({
+          attributes: ['type'],
+        });
+
+        if (Object.hasOwn(fullEcsMetadataList?.fields, strippedFieldName)) {
           const ecsMetadata = await fieldsMetadataClient.find({
             fieldNames: [strippedFieldName],
             attributes: ['description'],
@@ -204,13 +255,12 @@ export const ESQLLang: CustomLangModuleType<ESQLDependencies, MonacoMessage> = {
 
           const fieldMetadata = ecsMetadata.fields[strippedFieldName];
           if (fieldMetadata && fieldMetadata.description) {
-            const completionItem: monaco.languages.CompletionItem = {
+            return {
               ...item,
               documentation: {
                 value: fieldMetadata.description,
               },
             };
-            return completionItem;
           }
         }
 

--- a/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/components/field_popover/field_popover_header.tsx
@@ -39,6 +39,10 @@ export interface FieldPopoverHeaderProps {
   services?: {
     fieldsMetadata?: FieldsMetadataPublicStart;
   };
+  /**
+   * Optional stream name to fetch stream-specific field descriptions
+   */
+  streamName?: string;
 }
 
 export const FieldPopoverHeader: React.FC<FieldPopoverHeaderProps> = ({
@@ -55,6 +59,7 @@ export const FieldPopoverHeader: React.FC<FieldPopoverHeaderProps> = ({
   onEditField,
   onDeleteField,
   services,
+  streamName,
 }) => {
   if (!field) {
     return null;
@@ -195,6 +200,7 @@ export const FieldPopoverHeader: React.FC<FieldPopoverHeaderProps> = ({
         field={field}
         Wrapper={FieldDescriptionWrapper}
         fieldsMetadataService={services?.fieldsMetadata}
+        streamName={streamName}
       />
     </>
   );

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_item/field_list_item.tsx
@@ -211,6 +211,10 @@ export interface UnifiedFieldListItemProps {
    * Custom filters to apply for the field list, ex: namespace custom filter
    */
   additionalFilters?: Filter[];
+  /**
+   * Optional stream name to fetch stream-specific field descriptions
+   */
+  streamName?: string;
 }
 
 function UnifiedFieldListItemComponent({
@@ -236,6 +240,7 @@ function UnifiedFieldListItemComponent({
   itemIndex,
   size,
   additionalFilters,
+  streamName,
 }: UnifiedFieldListItemProps) {
   const [infoIsOpen, setOpen] = useState(false);
 
@@ -412,6 +417,7 @@ function UnifiedFieldListItemComponent({
           onDeleteField={onDeleteField}
           onEditField={onEditField}
           services={services}
+          streamName={streamName}
           {...customPopoverHeaderProps}
         />
       )}

--- a/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar.tsx
+++ b/src/platform/packages/shared/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar.tsx
@@ -52,6 +52,7 @@ export type UnifiedFieldListSidebarCustomizableProps = Pick<
   | 'onAddFieldToWorkspace'
   | 'onRemoveFieldFromWorkspace'
   | 'additionalFilters'
+  | 'streamName'
 > & {
   /**
    * All fields: fields from data view and unmapped fields or columns from text-based search
@@ -171,6 +172,7 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
   onToggleSidebar,
   additionalFilters,
   additionalFieldGroups,
+  streamName,
 }) => {
   const styles = useMemoCss(componentStyles);
 
@@ -285,6 +287,7 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
           services={services}
           size={compressed ? 'xs' : 's'}
           stateService={stateService}
+          streamName={streamName}
           trackUiMetric={trackUiMetric}
           workspaceSelectedFieldNames={workspaceSelectedFieldNames}
         />
@@ -308,6 +311,7 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
       workspaceSelectedFieldNames,
       selectedFieldsState.selectedFieldsMap,
       additionalFilters,
+      streamName,
     ]
   );
 

--- a/x-pack/platform/plugins/shared/fields_metadata/common/fields_metadata/types.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/common/fields_metadata/types.ts
@@ -15,6 +15,7 @@ export const fieldSourceRT = rt.keyof({
   integration: null,
   metadata: null,
   otel: null,
+  streams: null,
   unknown: null,
 });
 

--- a/x-pack/platform/plugins/shared/fields_metadata/common/fields_metadata/v1/find_fields_metadata.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/common/fields_metadata/v1/find_fields_metadata.ts
@@ -20,6 +20,7 @@ const baseFindFieldsMetadataRequestQueryRT = rt.exact(
     source: rt.union([fieldSourceRT, rt.array(fieldSourceRT)]),
     integration: rt.string,
     dataset: rt.string,
+    streamName: rt.string,
   })
 );
 
@@ -55,6 +56,7 @@ export type FindFieldsMetadataRequestQuery =
       source?: FieldSource | FieldSource[];
       integration?: undefined;
       dataset?: undefined;
+      streamName?: string;
     }
   | {
       attributes?: FieldAttribute[];
@@ -62,6 +64,7 @@ export type FindFieldsMetadataRequestQuery =
       source?: FieldSource | FieldSource[];
       integration: string;
       dataset: typeof ANY_DATASET | (string & {});
+      streamName?: string;
     };
 
 export type FindFieldsMetadataResponsePayload = rt.TypeOf<

--- a/x-pack/platform/plugins/shared/fields_metadata/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/mocks.ts
@@ -16,6 +16,8 @@ const createFieldsMetadataServerSetupMock = (): jest.Mocked<FieldsMetadataServer
     createFieldsMetadataServiceSetupMock().registerIntegrationFieldsExtractor,
   registerIntegrationListExtractor:
     createFieldsMetadataServiceSetupMock().registerIntegrationListExtractor,
+  registerStreamsFieldsExtractor:
+    createFieldsMetadataServiceSetupMock().registerStreamsFieldsExtractor,
 });
 
 const createFieldsMetadataServerStartMock = (): jest.Mocked<FieldsMetadataServerStart> => ({

--- a/x-pack/platform/plugins/shared/fields_metadata/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/plugin.ts
@@ -53,6 +53,7 @@ export class FieldsMetadataPlugin
     return {
       registerIntegrationFieldsExtractor: fieldsMetadata.registerIntegrationFieldsExtractor,
       registerIntegrationListExtractor: fieldsMetadata.registerIntegrationListExtractor,
+      registerStreamsFieldsExtractor: fieldsMetadata.registerStreamsFieldsExtractor,
     };
   }
 

--- a/x-pack/platform/plugins/shared/fields_metadata/server/routes/fields_metadata/find_fields_metadata.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/routes/fields_metadata/find_fields_metadata.ts
@@ -38,7 +38,7 @@ export const initFindFieldsMetadataRoute = ({
         },
       },
       async (_requestContext, request, response) => {
-        const { attributes, fieldNames, integration, dataset, source } = request.query;
+        const { attributes, fieldNames, integration, dataset, source, streamName } = request.query;
         const [_core, _startDeps, startContract] = await getStartServices();
 
         const fieldsMetadataClient = await startContract.getClient(request);
@@ -49,6 +49,7 @@ export const initFindFieldsMetadataRoute = ({
             integration,
             dataset,
             source,
+            streamName,
           });
 
           const responsePayload: FindFieldsMetadataResponsePayload = { fields: {} };

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_service.mock.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_service.mock.ts
@@ -13,6 +13,7 @@ export const createFieldsMetadataServiceSetupMock =
   (): jest.Mocked<FieldsMetadataServiceSetup> => ({
     registerIntegrationFieldsExtractor: jest.fn(),
     registerIntegrationListExtractor: jest.fn(),
+    registerStreamsFieldsExtractor: jest.fn(),
   });
 
 export const createFieldsMetadataServiceStartMock =

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_service.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/fields_metadata_service.ts
@@ -13,13 +13,19 @@ import { EcsFieldsRepository } from './repositories/ecs_fields_repository';
 import { IntegrationFieldsRepository } from './repositories/integration_fields_repository';
 import { MetadataFieldsRepository } from './repositories/metadata_fields_repository';
 import { OtelFieldsRepository } from './repositories/otel_fields_repository';
-import type { IntegrationFieldsExtractor, IntegrationListExtractor } from './repositories/types';
+import { StreamsFieldsRepository } from './repositories/streams_fields_repository';
+import type {
+  IntegrationFieldsExtractor,
+  IntegrationListExtractor,
+  StreamsFieldsExtractor,
+} from './repositories/types';
 import type { FieldsMetadataServiceSetup, FieldsMetadataServiceStart } from './types';
 import { MetadataFields as metadataFields } from '../../../common/metadata_fields';
 
 export class FieldsMetadataService {
   private integrationFieldsExtractor: IntegrationFieldsExtractor = () => Promise.resolve({});
   private integrationListExtractor: IntegrationListExtractor = () => Promise.resolve([]);
+  private streamsFieldsExtractor: StreamsFieldsExtractor = () => Promise.resolve({});
 
   constructor(private readonly logger: Logger) {}
 
@@ -31,11 +37,15 @@ export class FieldsMetadataService {
       registerIntegrationListExtractor: (extractor: IntegrationListExtractor) => {
         this.integrationListExtractor = extractor;
       },
+      registerStreamsFieldsExtractor: (extractor: StreamsFieldsExtractor) => {
+        this.streamsFieldsExtractor = extractor;
+      },
     };
   }
 
   public start(core: CoreStart): FieldsMetadataServiceStart {
-    const { logger, integrationFieldsExtractor, integrationListExtractor } = this;
+    const { logger, integrationFieldsExtractor, integrationListExtractor, streamsFieldsExtractor } =
+      this;
 
     const ecsFieldsRepository = EcsFieldsRepository.create({ ecsFields });
     const metadataFieldsRepository = MetadataFieldsRepository.create({ metadataFields });
@@ -44,6 +54,9 @@ export class FieldsMetadataService {
       integrationListExtractor,
     });
     const otelFieldsRepository = OtelFieldsRepository.create({ otelFields });
+    const streamsFieldsRepository = StreamsFieldsRepository.create({
+      streamsFieldsExtractor,
+    });
 
     return {
       getClient: async (request) => {
@@ -58,6 +71,7 @@ export class FieldsMetadataService {
           metadataFieldsRepository,
           integrationFieldsRepository,
           otelFieldsRepository,
+          streamsFieldsRepository,
         });
       },
     };

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/repositories/streams_fields_repository.test.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/repositories/streams_fields_repository.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { StreamsFieldsRepository } from './streams_fields_repository';
+import { FieldMetadata } from '../../../../common/fields_metadata/models/field_metadata';
+import type { ExtractedStreamFields, StreamsFieldsExtractor } from './types';
+
+describe('StreamsFieldsRepository class', () => {
+  const mockStreamFields: ExtractedStreamFields = {
+    message: {
+      name: 'message',
+      type: 'keyword',
+      description: 'Log message from the stream',
+      flat_name: 'message',
+    },
+    'stream.custom_field': {
+      name: 'stream.custom_field',
+      type: 'keyword',
+      description: 'A custom field defined in the stream',
+      flat_name: 'stream.custom_field',
+    },
+  };
+
+  let streamsFieldsExtractor: jest.MockedFunction<StreamsFieldsExtractor>;
+
+  beforeEach(() => {
+    streamsFieldsExtractor = jest.fn().mockResolvedValue(mockStreamFields);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a StreamsFieldsRepository instance', () => {
+      const repository = StreamsFieldsRepository.create({
+        streamsFieldsExtractor,
+      });
+
+      expect(repository).toBeInstanceOf(StreamsFieldsRepository);
+    });
+  });
+
+  describe('getByName', () => {
+    let repository: StreamsFieldsRepository;
+
+    beforeEach(() => {
+      repository = StreamsFieldsRepository.create({
+        streamsFieldsExtractor,
+      });
+    });
+
+    it('should return undefined when streamName is not provided', async () => {
+      const field = await repository.getByName('message', {});
+
+      expect(field).toBeUndefined();
+      expect(streamsFieldsExtractor).not.toHaveBeenCalled();
+    });
+
+    it('should fetch and return a field when streamName is provided', async () => {
+      const field = await repository.getByName('message', { streamName: 'logs' });
+
+      expect(streamsFieldsExtractor).toHaveBeenCalledWith({ streamName: 'logs' });
+      expect(field).toBeInstanceOf(FieldMetadata);
+      expect(field?.name).toBe('message');
+      expect(field?.description).toBe('Log message from the stream');
+      expect(field?.source).toBe('streams');
+    });
+
+    it('should return undefined for non-existent fields', async () => {
+      const field = await repository.getByName('non.existent.field', { streamName: 'logs' });
+
+      expect(streamsFieldsExtractor).toHaveBeenCalledWith({ streamName: 'logs' });
+      expect(field).toBeUndefined();
+    });
+
+    it('should cache fields after the first fetch', async () => {
+      // First call
+      await repository.getByName('message', { streamName: 'logs' });
+      expect(streamsFieldsExtractor).toHaveBeenCalledTimes(1);
+
+      // Second call - should use cache
+      await repository.getByName('stream.custom_field', { streamName: 'logs' });
+      expect(streamsFieldsExtractor).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fetch fields again for different streams', async () => {
+      await repository.getByName('message', { streamName: 'logs' });
+      expect(streamsFieldsExtractor).toHaveBeenCalledTimes(1);
+
+      await repository.getByName('message', { streamName: 'logs.nginx' });
+      expect(streamsFieldsExtractor).toHaveBeenCalledTimes(2);
+    });
+
+    it('should properly set source to "streams" for all fields', async () => {
+      const field = await repository.getByName('stream.custom_field', { streamName: 'logs' });
+
+      expect(field?.source).toBe('streams');
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/repositories/streams_fields_repository.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/repositories/streams_fields_repository.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FieldMetadata } from '../../../../common/fields_metadata/models/field_metadata';
+import { HashedCache } from '../../../../common/hashed_cache';
+import type { AnyFieldName } from '../../../../common';
+import type {
+  ExtractedStreamFields,
+  StreamsFieldsExtractor,
+  StreamsFieldsSearchParams,
+} from './types';
+
+interface StreamsFieldsRepositoryDeps {
+  streamsFieldsExtractor: StreamsFieldsExtractor;
+}
+
+type StreamFieldsMetadata = Record<string, FieldMetadata>;
+
+export class StreamsFieldsRepository {
+  private cache: HashedCache<StreamsFieldsSearchParams, StreamFieldsMetadata>;
+
+  private constructor(private readonly streamsFieldsExtractor: StreamsFieldsExtractor) {
+    this.cache = new HashedCache();
+  }
+
+  async getByName(
+    fieldName: AnyFieldName,
+    params: Partial<StreamsFieldsSearchParams>
+  ): Promise<FieldMetadata | undefined> {
+    const { streamName } = params;
+
+    if (!streamName) {
+      return undefined;
+    }
+
+    let field = this.getCachedField(fieldName, { streamName });
+
+    if (!field) {
+      await this.extractFields({ streamName });
+      field = this.getCachedField(fieldName, { streamName });
+    }
+
+    return field;
+  }
+
+  public static create({ streamsFieldsExtractor }: StreamsFieldsRepositoryDeps) {
+    return new StreamsFieldsRepository(streamsFieldsExtractor);
+  }
+
+  private async extractFields({ streamName }: StreamsFieldsSearchParams): Promise<void> {
+    const cacheKey = { streamName };
+    const cachedFields = this.cache.get(cacheKey);
+
+    if (cachedFields) {
+      return;
+    }
+
+    return this.streamsFieldsExtractor({ streamName })
+      .then(this.mapExtractedFieldsToFieldMetadata)
+      .then((fieldMetadata) => this.storeFieldsInCache(cacheKey, fieldMetadata));
+  }
+
+  private getCachedField(
+    fieldName: AnyFieldName,
+    { streamName }: StreamsFieldsSearchParams
+  ): FieldMetadata | undefined {
+    const cacheKey = { streamName };
+    const cachedFields = this.cache.get(cacheKey);
+
+    if (!cachedFields) {
+      return undefined;
+    }
+
+    return cachedFields[fieldName];
+  }
+
+  private storeFieldsInCache = (
+    cacheKey: StreamsFieldsSearchParams,
+    extractedFieldsMetadata: StreamFieldsMetadata
+  ): void => {
+    const cachedFields = this.cache.get(cacheKey);
+
+    if (!cachedFields) {
+      this.cache.set(cacheKey, extractedFieldsMetadata);
+    } else {
+      this.cache.set(cacheKey, { ...cachedFields, ...extractedFieldsMetadata });
+    }
+  };
+
+  private mapExtractedFieldsToFieldMetadata = (
+    extractedFields: ExtractedStreamFields
+  ): StreamFieldsMetadata => {
+    const fieldEntries = Object.entries(extractedFields);
+
+    return fieldEntries.reduce((fieldsMetadata, [fieldName, field]) => {
+      fieldsMetadata[fieldName] = FieldMetadata.create({ ...field, source: 'streams' });
+      return fieldsMetadata;
+    }, {} as StreamFieldsMetadata);
+  };
+}

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/repositories/types.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/repositories/types.ts
@@ -28,3 +28,15 @@ export interface ExtractedIntegration {
 }
 
 export type IntegrationListExtractor = () => Promise<ExtractedIntegration[]>;
+
+// Streams extractor types
+export interface StreamsFieldsSearchParams {
+  streamName: string;
+}
+
+export type StreamName = string;
+export type ExtractedStreamFields = Record<StreamName, FieldMetadataPlain>;
+
+export type StreamsFieldsExtractor = (
+  params: StreamsFieldsSearchParams
+) => Promise<ExtractedStreamFields>;

--- a/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/types.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/services/fields_metadata/types.ts
@@ -13,6 +13,8 @@ import type {
   IntegrationFieldsExtractor,
   IntegrationFieldsSearchParams,
   IntegrationListExtractor,
+  StreamsFieldsExtractor,
+  StreamsFieldsSearchParams,
 } from './repositories/types';
 
 export type * from './repositories/types';
@@ -23,13 +25,16 @@ export interface FieldsMetadataServiceStartDeps {}
 export interface FieldsMetadataServiceSetup {
   registerIntegrationFieldsExtractor: (extractor: IntegrationFieldsExtractor) => void;
   registerIntegrationListExtractor: (extractor: IntegrationListExtractor) => void;
+  registerStreamsFieldsExtractor: (extractor: StreamsFieldsExtractor) => void;
 }
 
 export interface FieldsMetadataServiceStart {
   getClient(request: KibanaRequest): Promise<IFieldsMetadataClient>;
 }
 
-export interface GetFieldsMetadataOptions extends Partial<IntegrationFieldsSearchParams> {
+export interface GetFieldsMetadataOptions
+  extends Partial<IntegrationFieldsSearchParams>,
+    Partial<StreamsFieldsSearchParams> {
   source?: FieldSource | FieldSource[];
 }
 

--- a/x-pack/platform/plugins/shared/fields_metadata/server/types.ts
+++ b/x-pack/platform/plugins/shared/fields_metadata/server/types.ts
@@ -22,6 +22,7 @@ export type FieldsMetadataPluginStartServicesAccessor =
 export interface FieldsMetadataServerSetup {
   registerIntegrationFieldsExtractor: FieldsMetadataServiceSetup['registerIntegrationFieldsExtractor'];
   registerIntegrationListExtractor: FieldsMetadataServiceSetup['registerIntegrationListExtractor'];
+  registerStreamsFieldsExtractor: FieldsMetadataServiceSetup['registerStreamsFieldsExtractor'];
 }
 
 export interface FieldsMetadataServerStart {

--- a/x-pack/platform/plugins/shared/streams/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/streams/server/plugin.ts
@@ -47,6 +47,7 @@ import { ProcessorSuggestionsService } from './lib/streams/ingest_pipelines/proc
 import { registerStreamsSavedObjects } from './lib/saved_objects/register_saved_objects';
 import { TaskService } from './lib/tasks/task_service';
 import { SystemService } from './lib/streams/system/system_service';
+import { registerFieldsMetadataExtractors } from './register_fields_metadata_extractors';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface StreamsPluginSetup {}
@@ -253,6 +254,13 @@ export class StreamsPlugin
         createStreamsGlobalSearchResultProvider(this.logger)
       );
     }
+
+    // Register streams field extractor with fields_metadata service
+    registerFieldsMetadataExtractors({
+      core,
+      fieldsMetadata: plugins.fieldsMetadata,
+      logger: this.logger,
+    });
 
     return {};
   }

--- a/x-pack/platform/plugins/shared/streams/server/register_fields_metadata_extractors.test.ts
+++ b/x-pack/platform/plugins/shared/streams/server/register_fields_metadata_extractors.test.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/server/mocks';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { fieldsMetadataPluginServerMock } from '@kbn/fields-metadata-plugin/server/mocks';
+import type { Streams } from '@kbn/streams-schema';
+import { registerFieldsMetadataExtractors } from './register_fields_metadata_extractors';
+
+// Mock the storage client module
+const mockStorageGet = jest.fn();
+const mockStorageSearch = jest.fn();
+
+jest.mock('./lib/streams/storage/streams_storage_client', () => ({
+  createStreamsStorageClient: jest.fn(() => ({
+    get: mockStorageGet,
+    search: mockStorageSearch,
+  })),
+}));
+
+function createWiredStreamDefinition(
+  name: string,
+  fields: Record<string, { type: string; description?: string }>
+): Streams.WiredStream.Definition {
+  return {
+    name,
+    description: '',
+    updated_at: new Date().toISOString(),
+    ingest: {
+      lifecycle: { inherit: {} },
+      processing: { steps: [], updated_at: new Date().toISOString() },
+      settings: {},
+      wired: {
+        fields,
+        routing: [],
+      },
+      failure_store: { inherit: {} },
+    },
+  };
+}
+
+function createClassicStreamDefinition(name: string): Streams.ClassicStream.Definition {
+  return {
+    name,
+    description: '',
+    updated_at: new Date().toISOString(),
+    ingest: {
+      lifecycle: { inherit: {} },
+      processing: { steps: [], updated_at: new Date().toISOString() },
+      settings: {},
+      classic: {},
+      failure_store: { inherit: {} },
+    },
+  };
+}
+
+describe('registerFieldsMetadataExtractors', () => {
+  let mockCore: ReturnType<typeof coreMock.createSetup>;
+  let mockFieldsMetadata: ReturnType<typeof fieldsMetadataPluginServerMock.createSetupContract>;
+  let mockLogger: ReturnType<typeof loggingSystemMock.createLogger>;
+  let registeredExtractor: (params: { streamName: string }) => Promise<Record<string, unknown>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCore = coreMock.createSetup();
+    mockFieldsMetadata = fieldsMetadataPluginServerMock.createSetupContract();
+    mockLogger = loggingSystemMock.createLogger();
+
+    // Capture the registered extractor
+    mockFieldsMetadata.registerStreamsFieldsExtractor.mockImplementation((extractor) => {
+      registeredExtractor = extractor;
+    });
+
+    registerFieldsMetadataExtractors({
+      core: mockCore,
+      fieldsMetadata: mockFieldsMetadata,
+      logger: mockLogger,
+    });
+  });
+
+  it('should register a streams field extractor', () => {
+    expect(mockFieldsMetadata.registerStreamsFieldsExtractor).toHaveBeenCalledTimes(1);
+    expect(typeof registeredExtractor).toBe('function');
+  });
+
+  describe('extractor', () => {
+    it('should return empty object when stream does not exist', async () => {
+      mockStorageGet.mockRejectedValueOnce(new Error('Not found'));
+
+      const result = await registeredExtractor({ streamName: 'logs.nonexistent' });
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty object for classic streams', async () => {
+      mockStorageGet.mockResolvedValueOnce({
+        _source: createClassicStreamDefinition('logs.classic'),
+      });
+
+      const result = await registeredExtractor({ streamName: 'logs.classic' });
+
+      expect(result).toEqual({});
+    });
+
+    it('should return field metadata for wired stream without ancestors', async () => {
+      const streamDef = createWiredStreamDefinition('logs', {
+        'service.name': { type: 'keyword', description: 'Name of the service' },
+        'host.ip': { type: 'ip' },
+      });
+
+      mockStorageGet.mockResolvedValueOnce({ _source: streamDef });
+
+      const result = await registeredExtractor({ streamName: 'logs' });
+
+      expect(result).toEqual({
+        'service.name': {
+          name: 'service.name',
+          type: 'keyword',
+          description: 'Name of the service',
+        },
+        'host.ip': {
+          name: 'host.ip',
+          type: 'ip',
+          description: undefined,
+        },
+      });
+    });
+
+    it('should include inherited fields from ancestors', async () => {
+      const childStream = createWiredStreamDefinition('logs.child', {
+        'child.field': { type: 'keyword', description: 'Child field' },
+      });
+
+      const parentStream = createWiredStreamDefinition('logs', {
+        'parent.field': { type: 'keyword', description: 'Parent field' },
+      });
+
+      mockStorageGet.mockResolvedValueOnce({ _source: childStream });
+      mockStorageSearch.mockResolvedValueOnce({
+        hits: { hits: [{ _source: parentStream }] },
+      });
+
+      const result = await registeredExtractor({ streamName: 'logs.child' });
+
+      expect(result).toEqual({
+        'parent.field': {
+          name: 'parent.field',
+          type: 'keyword',
+          description: 'Parent field',
+        },
+        'child.field': {
+          name: 'child.field',
+          type: 'keyword',
+          description: 'Child field',
+        },
+      });
+    });
+
+    it('should override inherited fields with own fields', async () => {
+      const childStream = createWiredStreamDefinition('logs.child', {
+        'shared.field': { type: 'keyword', description: 'Child description' },
+      });
+
+      const parentStream = createWiredStreamDefinition('logs', {
+        'shared.field': { type: 'keyword', description: 'Parent description' },
+      });
+
+      mockStorageGet.mockResolvedValueOnce({ _source: childStream });
+      mockStorageSearch.mockResolvedValueOnce({
+        hits: { hits: [{ _source: parentStream }] },
+      });
+
+      const result = await registeredExtractor({ streamName: 'logs.child' });
+
+      expect(result).toEqual({
+        'shared.field': {
+          name: 'shared.field',
+          type: 'keyword',
+          description: 'Child description',
+        },
+      });
+    });
+
+    it('should exclude type for system fields', async () => {
+      const streamDef = createWiredStreamDefinition('logs', {
+        '@timestamp': { type: 'system' },
+        'service.name': { type: 'keyword' },
+      });
+
+      mockStorageGet.mockResolvedValueOnce({ _source: streamDef });
+
+      const result = await registeredExtractor({ streamName: 'logs' });
+
+      expect(result).toEqual({
+        '@timestamp': {
+          name: '@timestamp',
+          type: undefined,
+          description: undefined,
+        },
+        'service.name': {
+          name: 'service.name',
+          type: 'keyword',
+          description: undefined,
+        },
+      });
+    });
+
+    it('should return empty object when storage get fails', async () => {
+      mockStorageGet.mockRejectedValueOnce(new Error('Connection failed'));
+
+      const result = await registeredExtractor({ streamName: 'logs.error' });
+
+      // The error is caught internally and returns empty object without logging
+      expect(result).toEqual({});
+    });
+
+    it('should handle ancestor search failures gracefully', async () => {
+      const childStream = createWiredStreamDefinition('logs.child', {
+        'child.field': { type: 'keyword' },
+      });
+
+      mockStorageGet.mockResolvedValueOnce({ _source: childStream });
+      mockStorageSearch.mockRejectedValueOnce(new Error('Search failed'));
+
+      const result = await registeredExtractor({ streamName: 'logs.child' });
+
+      // Should still return own fields even if ancestor search fails
+      expect(result).toEqual({
+        'child.field': {
+          name: 'child.field',
+          type: 'keyword',
+          description: undefined,
+        },
+      });
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams/server/register_fields_metadata_extractors.ts
+++ b/x-pack/platform/plugins/shared/streams/server/register_fields_metadata_extractors.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CoreSetup, Logger } from '@kbn/core/server';
+import type { FieldsMetadataServerSetup } from '@kbn/fields-metadata-plugin/server';
+import type { FieldMetadataPlain } from '@kbn/fields-metadata-plugin/common';
+import { getAncestors, getInheritedFieldsFromAncestors, Streams } from '@kbn/streams-schema';
+import type { StreamsPluginStartDependencies } from './types';
+import { createStreamsStorageClient } from './lib/streams/storage/streams_storage_client';
+
+interface RegistrationDeps {
+  core: CoreSetup<StreamsPluginStartDependencies>;
+  fieldsMetadata: FieldsMetadataServerSetup;
+  logger: Logger;
+}
+
+/**
+ * Registers a streams field extractor with the fields_metadata service.
+ * This allows the ESQL editor and field sidebar to display field descriptions
+ * for streams.
+ */
+export const registerFieldsMetadataExtractors = ({
+  core,
+  fieldsMetadata,
+  logger,
+}: RegistrationDeps) => {
+  fieldsMetadata.registerStreamsFieldsExtractor(async ({ streamName }) => {
+    try {
+      const [coreStart] = await core.getStartServices();
+      const esClient = coreStart.elasticsearch.client.asInternalUser;
+      const storageClient = createStreamsStorageClient(esClient, logger);
+
+      // Fetch the stream definition
+      const streamResponse = await storageClient.get({ id: streamName }).catch(() => null);
+
+      if (!streamResponse?._source) {
+        return {};
+      }
+
+      const streamDefinition = streamResponse._source;
+
+      // Only wired streams have field definitions
+      if (!Streams.WiredStream.Definition.is(streamDefinition)) {
+        return {};
+      }
+
+      // Fetch ancestors to get inherited fields
+      const ancestorIds = getAncestors(streamName);
+      let ancestors: Streams.WiredStream.Definition[] = [];
+
+      if (ancestorIds.length > 0) {
+        const ancestorsResponse = await storageClient
+          .search({
+            size: ancestorIds.length,
+            track_total_hits: false,
+            query: {
+              bool: {
+                filter: [{ terms: { name: ancestorIds } }],
+              },
+            },
+          })
+          .catch(() => ({ hits: { hits: [] } }));
+
+        ancestors = ancestorsResponse.hits.hits
+          .map((hit) => hit._source)
+          .filter((source): source is Streams.WiredStream.Definition =>
+            Streams.WiredStream.Definition.is(source)
+          );
+      }
+
+      // Get inherited fields from ancestors
+      const inheritedFields = getInheritedFieldsFromAncestors(ancestors);
+
+      // Combine own fields and inherited fields into field metadata
+      // ExtractedStreamFields is Record<FieldName, FieldMetadataPlain>
+      const fieldsMetadataResult: Record<string, FieldMetadataPlain> = {};
+
+      // Add inherited fields first (they can be overridden by own fields)
+      for (const [fieldName, fieldConfig] of Object.entries(inheritedFields)) {
+        fieldsMetadataResult[fieldName] = {
+          name: fieldName,
+          type: fieldConfig.type !== 'system' ? fieldConfig.type : undefined,
+          description: (fieldConfig as { description?: string }).description,
+        };
+      }
+
+      // Add own fields (they override inherited fields)
+      for (const [fieldName, fieldConfig] of Object.entries(streamDefinition.ingest.wired.fields)) {
+        fieldsMetadataResult[fieldName] = {
+          name: fieldName,
+          type: fieldConfig.type !== 'system' ? fieldConfig.type : undefined,
+          description: (fieldConfig as { description?: string }).description,
+        };
+      }
+
+      return fieldsMetadataResult;
+    } catch (error) {
+      logger.warn(`registerStreamsFieldsExtractor error: ${error}`);
+      return {};
+    }
+  });
+};

--- a/x-pack/platform/plugins/shared/streams/server/types.ts
+++ b/x-pack/platform/plugins/shared/streams/server/types.ts
@@ -26,7 +26,10 @@ import type {
   TaskManagerStartContract,
 } from '@kbn/task-manager-plugin/server';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
-import type { FieldsMetadataServerStart } from '@kbn/fields-metadata-plugin/server';
+import type {
+  FieldsMetadataServerSetup,
+  FieldsMetadataServerStart,
+} from '@kbn/fields-metadata-plugin/server';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/server';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import type { ConsoleStart as ConsoleServerStart } from '@kbn/console-plugin/server';
@@ -54,6 +57,7 @@ export interface StreamsPluginSetupDependencies {
   ruleRegistry: RuleRegistryPluginSetup;
   features: FeaturesPluginSetup;
   usageCollection: UsageCollectionSetup;
+  fieldsMetadata: FieldsMetadataServerSetup;
   cloud?: CloudSetup;
   globalSearch?: GlobalSearchPluginSetup;
 }

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/field_descriptions.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/field_descriptions.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { emptyAssets, type Streams } from '@kbn/streams-schema';
+import type { DeploymentAgnosticFtrProviderContext } from '../../ftr_provider_context';
+import type { StreamsSupertestRepositoryClient } from './helpers/repository_client';
+import { createStreamsRepositoryAdminClient } from './helpers/repository_client';
+import { disableStreams, enableStreams, putStream, deleteStream } from './helpers/requests';
+
+export default function ({ getService }: DeploymentAgnosticFtrProviderContext) {
+  const roleScopedSupertest = getService('roleScopedSupertest');
+  let apiClient: StreamsSupertestRepositoryClient;
+  let supertestAdmin: Awaited<
+    ReturnType<ReturnType<typeof roleScopedSupertest>['getSupertestWithRoleScope']>
+  >;
+
+  describe('Stream Field Descriptions', () => {
+    before(async () => {
+      apiClient = await createStreamsRepositoryAdminClient(roleScopedSupertest);
+      // Get a supertest client with internal headers for the fields_metadata API
+      supertestAdmin = await roleScopedSupertest.getSupertestWithRoleScope('admin', {
+        withInternalHeaders: true,
+      });
+      await enableStreams(apiClient);
+    });
+
+    after(async () => {
+      await disableStreams(apiClient);
+      await supertestAdmin.destroy();
+    });
+
+    describe('fields_metadata API integration', () => {
+      const STREAM_NAME = 'logs.field-descriptions-test';
+
+      before(async () => {
+        // Create a stream with field definitions
+        // Note: Field descriptions will be supported after PR #250785 is merged
+        const streamBody: Streams.WiredStream.UpsertRequest = {
+          ...emptyAssets,
+          stream: {
+            description: 'Test stream for field metadata integration',
+            ingest: {
+              lifecycle: { inherit: {} },
+              processing: { steps: [] },
+              settings: {},
+              wired: {
+                fields: {
+                  'attributes.custom_field': {
+                    type: 'keyword',
+                  },
+                  'attributes.another_field': {
+                    type: 'long',
+                  },
+                  'attributes.bool_field': {
+                    type: 'boolean',
+                  },
+                },
+                routing: [],
+              },
+              failure_store: { inherit: {} },
+            },
+          },
+        };
+
+        await putStream(apiClient, STREAM_NAME, streamBody);
+      });
+
+      after(async () => {
+        await deleteStream(apiClient, STREAM_NAME);
+      });
+
+      it('returns field metadata for a stream via fields_metadata API', async () => {
+        const response = await supertestAdmin
+          .get(
+            `/internal/fields_metadata?streamName=${STREAM_NAME}&fieldNames=attributes.custom_field,attributes.another_field,attributes.bool_field`
+          )
+          .set('Elastic-Api-Version', '1')
+          .expect(200);
+
+        expect(response.body).to.have.property('fields');
+
+        // Check that custom_field is returned with correct type and source
+        const customField = response.body.fields['attributes.custom_field'];
+        expect(customField).to.be.ok();
+        expect(customField.name).to.eql('attributes.custom_field');
+        expect(customField.type).to.eql('keyword');
+        expect(customField.source).to.eql('streams');
+
+        // Check that another_field is returned with correct type and source
+        const anotherField = response.body.fields['attributes.another_field'];
+        expect(anotherField).to.be.ok();
+        expect(anotherField.name).to.eql('attributes.another_field');
+        expect(anotherField.type).to.eql('long');
+        expect(anotherField.source).to.eql('streams');
+
+        // Check that bool_field is returned with correct type and source
+        const boolField = response.body.fields['attributes.bool_field'];
+        expect(boolField).to.be.ok();
+        expect(boolField.name).to.eql('attributes.bool_field');
+        expect(boolField.type).to.eql('boolean');
+        expect(boolField.source).to.eql('streams');
+      });
+
+      it('returns empty fields for non-existent stream', async () => {
+        const response = await supertestAdmin
+          .get(
+            `/internal/fields_metadata?streamName=non-existent-stream&fieldNames=attributes.custom_field`
+          )
+          .set('Elastic-Api-Version', '1')
+          .expect(200);
+
+        expect(response.body).to.have.property('fields');
+        // The field should not be found from the non-existent stream
+        // It might be empty or fall back to other sources
+        const customField = response.body.fields['attributes.custom_field'];
+        // If no source has this field, it should be undefined or from a different source
+        if (customField) {
+          expect(customField.source).to.not.eql('streams');
+        }
+      });
+
+      it('returns stream fields with highest priority over other sources', async () => {
+        // Query for a field that is defined on the stream
+        const response = await supertestAdmin
+          .get(
+            `/internal/fields_metadata?streamName=${STREAM_NAME}&fieldNames=attributes.custom_field`
+          )
+          .set('Elastic-Api-Version', '1')
+          .expect(200);
+
+        expect(response.body).to.have.property('fields');
+        const customField = response.body.fields['attributes.custom_field'];
+        expect(customField).to.be.ok();
+        // Stream source should have highest priority
+        expect(customField.source).to.eql('streams');
+      });
+    });
+
+    describe('inherited field metadata', () => {
+      const PARENT_STREAM = 'logs.parent-stream';
+      const CHILD_STREAM = 'logs.parent-stream.child';
+
+      before(async () => {
+        // Create parent stream with field definitions
+        const parentBody: Streams.WiredStream.UpsertRequest = {
+          ...emptyAssets,
+          stream: {
+            description: 'Parent stream',
+            ingest: {
+              lifecycle: { inherit: {} },
+              processing: { steps: [] },
+              settings: {},
+              wired: {
+                fields: {
+                  'attributes.inherited_field': {
+                    type: 'keyword',
+                  },
+                },
+                routing: [],
+              },
+              failure_store: { inherit: {} },
+            },
+          },
+        };
+
+        await putStream(apiClient, PARENT_STREAM, parentBody);
+
+        // Create child stream with its own field
+        const childBody: Streams.WiredStream.UpsertRequest = {
+          ...emptyAssets,
+          stream: {
+            description: 'Child stream',
+            ingest: {
+              lifecycle: { inherit: {} },
+              processing: { steps: [] },
+              settings: {},
+              wired: {
+                fields: {
+                  'attributes.child_field': {
+                    type: 'keyword',
+                  },
+                },
+                routing: [],
+              },
+              failure_store: { inherit: {} },
+            },
+          },
+        };
+
+        await putStream(apiClient, CHILD_STREAM, childBody);
+      });
+
+      after(async () => {
+        await deleteStream(apiClient, CHILD_STREAM);
+        await deleteStream(apiClient, PARENT_STREAM);
+      });
+
+      it('returns inherited field metadata for child stream', async () => {
+        const response = await supertestAdmin
+          .get(
+            `/internal/fields_metadata?streamName=${CHILD_STREAM}&fieldNames=attributes.inherited_field,attributes.child_field`
+          )
+          .set('Elastic-Api-Version', '1')
+          .expect(200);
+
+        expect(response.body).to.have.property('fields');
+
+        // Check inherited field from parent
+        const inheritedField = response.body.fields['attributes.inherited_field'];
+        expect(inheritedField).to.be.ok();
+        expect(inheritedField.name).to.eql('attributes.inherited_field');
+        expect(inheritedField.type).to.eql('keyword');
+        expect(inheritedField.source).to.eql('streams');
+
+        // Check child's own field
+        const childField = response.body.fields['attributes.child_field'];
+        expect(childField).to.be.ok();
+        expect(childField.name).to.eql('attributes.child_field');
+        expect(childField.type).to.eql('keyword');
+        expect(childField.source).to.eql('streams');
+      });
+    });
+  });
+}

--- a/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
+++ b/x-pack/platform/test/api_integration_deployment_agnostic/apis/streams/index.ts
@@ -35,5 +35,6 @@ export default function ({ loadTestFile }: DeploymentAgnosticFtrProviderContext)
     loadTestFile(require.resolve('./settings'));
     loadTestFile(require.resolve('./doc_counts'));
     loadTestFile(require.resolve('./snapshot_restore'));
+    loadTestFile(require.resolve('./field_descriptions'));
   });
 }


### PR DESCRIPTION
## 🍒 Summary

> ⚠️ **Depends on #250785** - This PR is stacked on top of the field descriptions PR and should be merged after it.

This PR adds support for showing stream-specific field descriptions in the ESQL editor autocomplete and the Discover field sidebar when querying from a stream (`FROM <stream_name>`).

This builds on top of #250785 which adds the `description` property to stream field definitions.

## 🛠️ Changes

### fields_metadata service
- Added 'streams' as a new `FieldSource` type
- Created `StreamsFieldsRepository` class to cache and fetch stream field metadata
- Added `registerStreamsFieldsExtractor` method to allow plugins to register field extractors
- Updated `FieldsMetadataClient` to query streams repository when `streamName` parameter is provided
- Added `streamName` parameter to the HTTP API (`/internal/fields_metadata`)

### streams plugin
- Created `register_fields_metadata_extractors.ts` to register field extractor at setup
- Extractor fetches field definitions including descriptions for a given stream name
- Handles inherited fields from parent streams (wired streams)

### ESQL editor
- Added `extractSourceFromQuery()` function to parse FROM clause and extract stream name
- Updated `resolveCompletionItem` to fetch stream-specific field descriptions
- Falls back to ECS metadata if no stream-specific description found

### Discover sidebar
- Added `streamName` prop to `FieldDescription`, `FieldPopoverHeader`, and `UnifiedFieldListItem`
- Updated `UnifiedFieldListSidebarContainer` to extract stream name from ES|QL query
- Stream field descriptions are now displayed when viewing a stream in Discover

### Tests
- Added unit tests for `StreamsFieldsRepository`
- Added unit tests for streams fields extractor
- Added unit tests for `extractSourceFromQuery` in ESQL editor
- Added API integration tests for streams fields_metadata integration

## 🎙️ Prompts

- "Show streams field descriptions in the ESQL editor autocomplete and field sidebar in Discover when querying from a stream"

🤖 This pull request was assisted by Cursor
