### PR TITLE
Add Elky easter egg to Streams UI search

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -357,11 +357,41 @@ export function StreamsTreeTable({
             font-size: ${euiTheme.size.l};
             background-color: ${euiTheme.colors.lightestShade};
             border-radius: ${euiTheme.border.radius.medium};
+            @keyframes rotate {
+              from {
+                transform: rotate(0deg);
+              }
+              to {
+                transform: rotate(360deg);
+              }
+            }
+            .rotating-elk {
+              display: inline-block;
+              animation: rotate 2s linear infinite;
+            }
           `}
         >
-          <span role="img" aria-label="Elk emoji banner">
-            🦌 🦌 🦌 Elky is here! 🦌 🦌 🦌
-          </span>
+          <>
+            <span className="rotating-elk" role="img" aria-label="Elk emoji">
+              🦌
+            </span>{' '}
+            <span className="rotating-elk" role="img" aria-label="Elk emoji">
+              🦌
+            </span>{' '}
+            <span className="rotating-elk" role="img" aria-label="Elk emoji">
+              🦌
+            </span>{' '}
+            Elky is here!{' '}
+            <span className="rotating-elk" role="img" aria-label="Elk emoji">
+              🦌
+            </span>{' '}
+            <span className="rotating-elk" role="img" aria-label="Elk emoji">
+              🦌
+            </span>{' '}
+            <span className="rotating-elk" role="img" aria-label="Elk emoji">
+              🦌
+            </span>
+          </>
         </div>
       )}
       <EuiInMemoryTable<TableRow>

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -35,6 +35,7 @@ import {
   filterStreamsByQuery,
   filterCollapsedStreamRows,
   getLegacyLogsStatus,
+  isElkyEasterEggQuery,
 } from './utils';
 import { StreamsAppSearchBar } from '../streams_app_search_bar';
 import { DocumentsColumn } from './documents_column';
@@ -339,262 +340,298 @@ export function StreamsTreeTable({
     </EuiFlexGroup>
   );
 
+  // Detect Elky easter egg query
+  const isElkyQuery = React.useMemo(() => {
+    return isElkyEasterEggQuery(searchQuery?.text);
+  }, [searchQuery?.text]);
+
   return (
-    <EuiInMemoryTable<TableRow>
-      loading={loading}
-      data-test-subj="streamsTable"
-      columns={[
-        {
-          field: 'nameSortKey',
-          name: nameColumnHeader,
-          sortable: (row: TableRow) => row.rootNameSortKey,
-          dataType: 'string',
-          render: (_: unknown, item: TableRow) => {
-            // Only show expand/collapse if tree mode is active and has children
-            const treeMode = shouldComposeTree(sortField);
-            const hasChildren = !!item.children && item.children.length > 0;
-            const isCollapsed = collapsed.has(item.stream.name);
-            return (
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-                responsive={false}
-                className={css`
-                  margin-left: ${item.level * parseInt(euiTheme.size.xl, 10)}px;
-                `}
-              >
-                {treeMode && item.children && hasChildren && (
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon
-                      type={isCollapsed ? 'arrowRight' : 'arrowDown'}
-                      color="text"
-                      size="m"
-                      data-test-subj={`${isCollapsed ? 'expand' : 'collapse'}Button-${
-                        item.stream.name
-                      }`}
-                      aria-label={
-                        isCollapsed
-                          ? i18n.translate(
-                              'xpack.streams.streamsTreeTable.collapsedNodeAriaLabel',
-                              {
-                                defaultMessage: 'Collapsed node with {childCount} children',
-                                values: { childCount: item.children.length },
-                              }
-                            )
-                          : i18n.translate('xpack.streams.streamsTreeTable.expandedNodeAriaLabel', {
-                              defaultMessage: 'Expanded node with {childCount} children',
-                              values: { childCount: item.children.length },
-                            })
-                      }
-                      onClick={(e: React.MouseEvent) => {
-                        handleToggleCollapse(item.stream.name);
-                      }}
-                      tabIndex={0}
-                      role="button"
-                      onKeyDown={(e: React.KeyboardEvent) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          handleToggleCollapse(item.stream.name);
+    <>
+      {isElkyQuery && (
+        <div
+          data-test-subj="elkyEasterEggBanner"
+          className={css`
+            padding: ${euiTheme.size.base};
+            margin-bottom: ${euiTheme.size.base};
+            text-align: center;
+            font-size: ${euiTheme.size.l};
+            background-color: ${euiTheme.colors.lightestShade};
+            border-radius: ${euiTheme.border.radius.medium};
+          `}
+        >
+          <span role="img" aria-label="Elk emoji banner">
+            🦌 🦌 🦌 Elky is here! 🦌 🦌 🦌
+          </span>
+        </div>
+      )}
+      <EuiInMemoryTable<TableRow>
+        loading={loading}
+        data-test-subj="streamsTable"
+        columns={[
+          {
+            field: 'nameSortKey',
+            name: nameColumnHeader,
+            sortable: (row: TableRow) => row.rootNameSortKey,
+            dataType: 'string',
+            render: (_: unknown, item: TableRow) => {
+              // Only show expand/collapse if tree mode is active and has children
+              const treeMode = shouldComposeTree(sortField);
+              const hasChildren = !!item.children && item.children.length > 0;
+              const isCollapsed = collapsed.has(item.stream.name);
+              return (
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="s"
+                  responsive={false}
+                  className={css`
+                    margin-left: ${item.level * parseInt(euiTheme.size.xl, 10)}px;
+                  `}
+                >
+                  {treeMode && item.children && hasChildren && (
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon
+                        type={isCollapsed ? 'arrowRight' : 'arrowDown'}
+                        color="text"
+                        size="m"
+                        data-test-subj={`${isCollapsed ? 'expand' : 'collapse'}Button-${
+                          item.stream.name
+                        }`}
+                        aria-label={
+                          isCollapsed
+                            ? i18n.translate(
+                                'xpack.streams.streamsTreeTable.collapsedNodeAriaLabel',
+                                {
+                                  defaultMessage: 'Collapsed node with {childCount} children',
+                                  values: { childCount: item.children.length },
+                                }
+                              )
+                            : i18n.translate(
+                                'xpack.streams.streamsTreeTable.expandedNodeAriaLabel',
+                                {
+                                  defaultMessage: 'Expanded node with {childCount} children',
+                                  values: { childCount: item.children.length },
+                                }
+                              )
                         }
-                      }}
-                      style={{ cursor: 'pointer' }}
-                    />
-                  </EuiFlexItem>
-                )}
-                {treeMode && !hasChildren && (
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon type="empty" color="text" size="m" aria-hidden="true" />
-                  </EuiFlexItem>
-                )}
-                <EuiFlexGroup alignItems="center" gutterSize="s" responsive wrap>
-                  <EuiLink
-                    data-test-subj={`streamsNameLink-${item.stream.name}`}
-                    href={router.link('/{key}', {
-                      path: { key: item.stream.name },
-                      query: { rangeFrom, rangeTo },
-                    })}
-                    onClick={(e: React.MouseEvent) => {
-                      e.preventDefault();
-                      router.push('/{key}', {
+                        onClick={(e: React.MouseEvent) => {
+                          handleToggleCollapse(item.stream.name);
+                        }}
+                        tabIndex={0}
+                        role="button"
+                        onKeyDown={(e: React.KeyboardEvent) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            handleToggleCollapse(item.stream.name);
+                          }
+                        }}
+                        style={{ cursor: 'pointer' }}
+                      />
+                    </EuiFlexItem>
+                  )}
+                  {treeMode && !hasChildren && (
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon type="empty" color="text" size="m" aria-hidden="true" />
+                    </EuiFlexItem>
+                  )}
+                  <EuiFlexGroup alignItems="center" gutterSize="s" responsive wrap>
+                    <EuiLink
+                      data-test-subj={`streamsNameLink-${item.stream.name}`}
+                      href={router.link('/{key}', {
                         path: { key: item.stream.name },
                         query: { rangeFrom, rangeTo },
-                      });
-                    }}
-                  >
-                    <EuiHighlight search={searchQuery?.text ?? ''}>{item.stream.name}</EuiHighlight>
-                  </EuiLink>
-                  {item.stream.name === LOGS_ROOT_STREAM_NAME && (
-                    <DeprecatedLogsBadge
-                      openFlyout={openFlyout}
-                      hasNewStreams={getLegacyLogsStatus(wiredStreamsStatus).hasNewStreams}
-                    />
-                  )}
-                  {Streams.QueryStream.Definition.is(item.stream) && <QueryStreamBadge />}
+                      })}
+                      onClick={(e: React.MouseEvent) => {
+                        e.preventDefault();
+                        router.push('/{key}', {
+                          path: { key: item.stream.name },
+                          query: { rangeFrom, rangeTo },
+                        });
+                      }}
+                    >
+                      <EuiHighlight search={searchQuery?.text ?? ''}>
+                        {item.stream.name}
+                      </EuiHighlight>
+                    </EuiLink>
+                    {item.stream.name === LOGS_ROOT_STREAM_NAME && (
+                      <DeprecatedLogsBadge
+                        openFlyout={openFlyout}
+                        hasNewStreams={getLegacyLogsStatus(wiredStreamsStatus).hasNewStreams}
+                      />
+                    )}
+                    {Streams.QueryStream.Definition.is(item.stream) && <QueryStreamBadge />}
+                  </EuiFlexGroup>
                 </EuiFlexGroup>
-              </EuiFlexGroup>
-            );
+              );
+            },
           },
-        },
-        {
-          field: 'documentsCount',
-          name: (
-            <EuiFlexGroup alignItems="center" gutterSize="s">
-              {DOCUMENTS_COLUMN_HEADER}
-              {!canReadFailureStore && (
-                <EuiIconTip
-                  content={FAILURE_STORE_PERMISSIONS_ERROR}
-                  type="warning"
-                  color="warning"
-                  size="s"
-                />
-              )}
-            </EuiFlexGroup>
-          ),
-          width: '180px',
-          sortable: docCountsLoaded ? (row: TableRow) => docsByStream[row.stream.name] ?? 0 : false,
-          align: 'right',
-          dataType: 'number',
-          render: (_: unknown, item: TableRow) =>
-            item.data_stream ? (
-              <DocumentsColumn
-                indexPattern={item.stream.name}
-                histogramQueryFetch={getStreamHistogram(item.stream.name)}
-                timeState={timeState}
-                numDataPoints={numDataPoints}
-              />
-            ) : null,
-        },
-        {
-          field: 'dataQuality',
-          name: (
-            <EuiFlexGroup alignItems="center" gutterSize="s">
-              {DATA_QUALITY_COLUMN_HEADER}
-              {!canReadFailureStore && (
-                <EuiIconTip
-                  content={FAILURE_STORE_PERMISSIONS_ERROR}
-                  type="warning"
-                  color="warning"
-                  size="s"
-                />
-              )}
-            </EuiFlexGroup>
-          ),
-          width: '150px',
-          sortable: qualityLoaded
-            ? (item: TableRow) => qualityRank[item.dataQuality as QualityIndicators]
-            : false,
-          dataType: 'string',
-          render: (_: unknown, item: TableRow) =>
-            item.data_stream ? (
-              <DataQualityColumn
-                streamName={item.stream.name}
-                quality={item.dataQuality as QualityIndicators}
-                isLoading={
-                  totalDocsResult.loading || failedDocsResult.loading || degradedDocsResult.loading
-                }
-              />
-            ) : (
-              '-'
+          {
+            field: 'documentsCount',
+            name: (
+              <EuiFlexGroup alignItems="center" gutterSize="s">
+                {DOCUMENTS_COLUMN_HEADER}
+                {!canReadFailureStore && (
+                  <EuiIconTip
+                    content={FAILURE_STORE_PERMISSIONS_ERROR}
+                    type="warning"
+                    color="warning"
+                    size="s"
+                  />
+                )}
+              </EuiFlexGroup>
             ),
-        },
-        {
-          field: 'retentionMs',
-          name: (
-            <span aria-label={RETENTION_COLUMN_HEADER_ARIA_LABEL}>{RETENTION_COLUMN_HEADER}</span>
+            width: '180px',
+            sortable: docCountsLoaded
+              ? (row: TableRow) => docsByStream[row.stream.name] ?? 0
+              : false,
+            align: 'right',
+            dataType: 'number',
+            render: (_: unknown, item: TableRow) =>
+              item.data_stream ? (
+                <DocumentsColumn
+                  indexPattern={item.stream.name}
+                  histogramQueryFetch={getStreamHistogram(item.stream.name)}
+                  timeState={timeState}
+                  numDataPoints={numDataPoints}
+                />
+              ) : null,
+          },
+          {
+            field: 'dataQuality',
+            name: (
+              <EuiFlexGroup alignItems="center" gutterSize="s">
+                {DATA_QUALITY_COLUMN_HEADER}
+                {!canReadFailureStore && (
+                  <EuiIconTip
+                    content={FAILURE_STORE_PERMISSIONS_ERROR}
+                    type="warning"
+                    color="warning"
+                    size="s"
+                  />
+                )}
+              </EuiFlexGroup>
+            ),
+            width: '150px',
+            sortable: qualityLoaded
+              ? (item: TableRow) => qualityRank[item.dataQuality as QualityIndicators]
+              : false,
+            dataType: 'string',
+            render: (_: unknown, item: TableRow) =>
+              item.data_stream ? (
+                <DataQualityColumn
+                  streamName={item.stream.name}
+                  quality={item.dataQuality as QualityIndicators}
+                  isLoading={
+                    totalDocsResult.loading ||
+                    failedDocsResult.loading ||
+                    degradedDocsResult.loading
+                  }
+                />
+              ) : (
+                '-'
+              ),
+          },
+          {
+            field: 'retentionMs',
+            name: (
+              <span aria-label={RETENTION_COLUMN_HEADER_ARIA_LABEL}>{RETENTION_COLUMN_HEADER}</span>
+            ),
+            align: 'left',
+            sortable: (row: TableRow) => row.rootRetentionMs,
+            dataType: 'number',
+            width: '220px',
+            render: (_: unknown, item: TableRow) => (
+              <RetentionColumn
+                lifecycle={item.effective_lifecycle!}
+                aria-label={i18n.translate(
+                  'xpack.streams.streamsTreeTable.retentionCellAriaLabel',
+                  {
+                    defaultMessage: 'Retention policy for {name}',
+                    values: { name: item.stream.name },
+                  }
+                )}
+                dataTestSubj={`retentionColumn-${item.stream.name}`}
+              />
+            ),
+          },
+          {
+            field: 'definition',
+            name: 'Actions',
+            width: '60px',
+            align: 'left',
+            sortable: false,
+            dataType: 'string',
+            render: (_: unknown, item: TableRow) => (
+              <DiscoverBadgeButton
+                hasDataStream={!!item.data_stream || Streams.QueryStream.Definition.is(item.stream)}
+                indexMode={item.data_stream?.index_mode}
+                stream={item.stream}
+              />
+            ),
+          },
+        ]}
+        itemId="name"
+        items={items}
+        sorting={sorting}
+        noItemsMessage={NO_STREAMS_MESSAGE}
+        onTableChange={handleTableChange}
+        pagination={{
+          initialPageSize: 25,
+          pageSizeOptions: [25, 50, 100],
+          pageIndex: pagination.pageIndex,
+          pageSize: pagination.pageSize,
+        }}
+        executeQueryOptions={{ enabled: false }}
+        search={{
+          query: searchQuery,
+          onChange: handleQueryChange,
+          box: {
+            incremental: true,
+            'aria-label': STREAMS_TABLE_SEARCH_ARIA_LABEL,
+          },
+          toolsRight: (
+            <div className={datePickerStyle}>
+              <StreamsAppSearchBar showDatePicker />
+            </div>
           ),
-          align: 'left',
-          sortable: (row: TableRow) => row.rootRetentionMs,
-          dataType: 'number',
-          width: '220px',
-          render: (_: unknown, item: TableRow) => (
-            <RetentionColumn
-              lifecycle={item.effective_lifecycle!}
-              aria-label={i18n.translate('xpack.streams.streamsTreeTable.retentionCellAriaLabel', {
-                defaultMessage: 'Retention policy for {name}',
-                values: { name: item.stream.name },
-              })}
-              dataTestSubj={`retentionColumn-${item.stream.name}`}
-            />
-          ),
-        },
-        {
-          field: 'definition',
-          name: 'Actions',
-          width: '60px',
-          align: 'left',
-          sortable: false,
-          dataType: 'string',
-          render: (_: unknown, item: TableRow) => (
-            <DiscoverBadgeButton
-              hasDataStream={!!item.data_stream || Streams.QueryStream.Definition.is(item.stream)}
-              indexMode={item.data_stream?.index_mode}
-              stream={item.stream}
-            />
-          ),
-        },
-      ]}
-      itemId="name"
-      items={items}
-      sorting={sorting}
-      noItemsMessage={NO_STREAMS_MESSAGE}
-      onTableChange={handleTableChange}
-      pagination={{
-        initialPageSize: 25,
-        pageSizeOptions: [25, 50, 100],
-        pageIndex: pagination.pageIndex,
-        pageSize: pagination.pageSize,
-      }}
-      executeQueryOptions={{ enabled: false }}
-      search={{
-        query: searchQuery,
-        onChange: handleQueryChange,
-        box: {
-          incremental: true,
-          'aria-label': STREAMS_TABLE_SEARCH_ARIA_LABEL,
-        },
-        toolsRight: (
-          <div className={datePickerStyle}>
-            <StreamsAppSearchBar showDatePicker />
-          </div>
-        ),
-        filters:
-          qualityLoaded && canReadFailureStore
-            ? [
-                {
-                  type: 'field_value_selection',
-                  name: i18n.translate('xpack.streams.streamsTreeTable.dataQualityFilter.label', {
-                    defaultMessage: 'Data quality',
-                  }),
-                  field: 'dataQuality',
-                  multiSelect: 'or',
-                  options: [
-                    {
-                      value: 'good',
-                      name: i18n.translate(
-                        'xpack.streams.streamsTreeTable.dataQualityFilter.goodLabel',
-                        { defaultMessage: 'Good' }
-                      ),
-                    },
-                    {
-                      value: 'degraded',
-                      name: i18n.translate(
-                        'xpack.streams.streamsTreeTable.dataQualityFilter.degradedLabel',
-                        { defaultMessage: 'Degraded' }
-                      ),
-                    },
-                    {
-                      value: 'poor',
-                      name: i18n.translate(
-                        'xpack.streams.streamsTreeTable.dataQualityFilter.poorLabel',
-                        { defaultMessage: 'Poor' }
-                      ),
-                    },
-                  ],
-                },
-              ]
-            : [],
-      }}
-      tableCaption={STREAMS_TABLE_CAPTION_ARIA_LABEL}
-    />
+          filters:
+            qualityLoaded && canReadFailureStore
+              ? [
+                  {
+                    type: 'field_value_selection',
+                    name: i18n.translate('xpack.streams.streamsTreeTable.dataQualityFilter.label', {
+                      defaultMessage: 'Data quality',
+                    }),
+                    field: 'dataQuality',
+                    multiSelect: 'or',
+                    options: [
+                      {
+                        value: 'good',
+                        name: i18n.translate(
+                          'xpack.streams.streamsTreeTable.dataQualityFilter.goodLabel',
+                          { defaultMessage: 'Good' }
+                        ),
+                      },
+                      {
+                        value: 'degraded',
+                        name: i18n.translate(
+                          'xpack.streams.streamsTreeTable.dataQualityFilter.degradedLabel',
+                          { defaultMessage: 'Degraded' }
+                        ),
+                      },
+                      {
+                        value: 'poor',
+                        name: i18n.translate(
+                          'xpack.streams.streamsTreeTable.dataQualityFilter.poorLabel',
+                          { defaultMessage: 'Poor' }
+                        ),
+                      },
+                    ],
+                  },
+                ]
+              : [],
+        }}
+        tableCaption={STREAMS_TABLE_CAPTION_ARIA_LABEL}
+      />
+    </>
   );
 }

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts
@@ -5,7 +5,13 @@
  * 2.0.
  */
 
-import { asTrees, buildStreamRows, enrichStream, filterCollapsedStreamRows } from './utils';
+import {
+  asTrees,
+  buildStreamRows,
+  enrichStream,
+  filterCollapsedStreamRows,
+  isElkyEasterEggQuery,
+} from './utils';
 import type { ListStreamDetail } from '@kbn/streams-plugin/server/routes/internal/streams/crud/route';
 import type { Direction } from '@elastic/eui';
 import { ms } from '@kbn/test/src/functional_test_runner/lib/mocha/reporter/ms';
@@ -267,5 +273,36 @@ describe('filterCollapsedStreamRows', () => {
     // Should include logs-a.child1, but not its grandchild
     expect(filtered.map((r) => r.stream.name)).toContain('logs.otel.child1');
     expect(filtered.map((r) => r.stream.name)).not.toContain('logs.otel.child1.grandchild');
+  });
+});
+
+describe('isElkyEasterEggQuery', () => {
+  it('returns true for exact match', () => {
+    expect(isElkyEasterEggQuery('Where is Elky?')).toBe(true);
+  });
+
+  it('returns true for case-insensitive match', () => {
+    expect(isElkyEasterEggQuery('where is elky?')).toBe(true);
+    expect(isElkyEasterEggQuery('WHERE IS ELKY?')).toBe(true);
+    expect(isElkyEasterEggQuery('WhErE iS eLkY?')).toBe(true);
+  });
+
+  it('returns true when surrounded by whitespace', () => {
+    expect(isElkyEasterEggQuery('  Where is Elky?  ')).toBe(true);
+    expect(isElkyEasterEggQuery('\t\nWhere is Elky?\n\t')).toBe(true);
+  });
+
+  it('returns false for non-matching queries', () => {
+    expect(isElkyEasterEggQuery('Where is Elky')).toBe(false);
+    expect(isElkyEasterEggQuery('Where is Elk?')).toBe(false);
+    expect(isElkyEasterEggQuery('Where is the elk?')).toBe(false);
+    expect(isElkyEasterEggQuery('logs')).toBe(false);
+    expect(isElkyEasterEggQuery('Elky')).toBe(false);
+  });
+
+  it('returns false for undefined or empty string', () => {
+    expect(isElkyEasterEggQuery(undefined)).toBe(false);
+    expect(isElkyEasterEggQuery('')).toBe(false);
+    expect(isElkyEasterEggQuery('   ')).toBe(false);
   });
 });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts
@@ -278,24 +278,24 @@ describe('filterCollapsedStreamRows', () => {
 
 describe('isElkyEasterEggQuery', () => {
   it('returns true for exact match', () => {
-    expect(isElkyEasterEggQuery('Where is Elky?')).toBe(true);
+    expect(isElkyEasterEggQuery('Where is Elky')).toBe(true);
   });
 
   it('returns true for case-insensitive match', () => {
-    expect(isElkyEasterEggQuery('where is elky?')).toBe(true);
-    expect(isElkyEasterEggQuery('WHERE IS ELKY?')).toBe(true);
-    expect(isElkyEasterEggQuery('WhErE iS eLkY?')).toBe(true);
+    expect(isElkyEasterEggQuery('where is elky')).toBe(true);
+    expect(isElkyEasterEggQuery('WHERE IS ELKY')).toBe(true);
+    expect(isElkyEasterEggQuery('WhErE iS eLkY')).toBe(true);
   });
 
   it('returns true when surrounded by whitespace', () => {
-    expect(isElkyEasterEggQuery('  Where is Elky?  ')).toBe(true);
-    expect(isElkyEasterEggQuery('\t\nWhere is Elky?\n\t')).toBe(true);
+    expect(isElkyEasterEggQuery('  Where is Elky  ')).toBe(true);
+    expect(isElkyEasterEggQuery('\t\nWhere is Elky\n\t')).toBe(true);
   });
 
   it('returns false for non-matching queries', () => {
-    expect(isElkyEasterEggQuery('Where is Elky')).toBe(false);
-    expect(isElkyEasterEggQuery('Where is Elk?')).toBe(false);
-    expect(isElkyEasterEggQuery('Where is the elk?')).toBe(false);
+    expect(isElkyEasterEggQuery('Where is Elky?')).toBe(false);
+    expect(isElkyEasterEggQuery('Where is Elk')).toBe(false);
+    expect(isElkyEasterEggQuery('Where is the elk')).toBe(false);
     expect(isElkyEasterEggQuery('logs')).toBe(false);
     expect(isElkyEasterEggQuery('Elky')).toBe(false);
   });

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
@@ -222,5 +222,5 @@ export const getLegacyLogsStatus = (
 // Detects the Elky easter egg query (case-insensitive, trimmed)
 export const isElkyEasterEggQuery = (queryText: string | undefined): boolean => {
   const trimmedQuery = queryText?.trim().toLowerCase() ?? '';
-  return trimmedQuery === 'where is elky?';
+  return trimmedQuery === 'where is elky';
 };

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
@@ -218,3 +218,9 @@ export const getLegacyLogsStatus = (
 
   return { hasLegacyLogs, hasNewStreams };
 };
+
+// Detects the Elky easter egg query (case-insensitive, trimmed)
+export const isElkyEasterEggQuery = (queryText: string | undefined): boolean => {
+  const trimmedQuery = queryText?.trim().toLowerCase() ?? '';
+  return trimmedQuery === 'where is elky?';
+};


### PR DESCRIPTION
## Summary

**Prompt:** Implement a Streams UI easter egg: when the stream search query is "Where is Elky?" (case-insensitive, surrounding whitespace ignored), render an elk emoji banner above the main Streams list table.

R

**Workflow run:** https://github.com/flash1293/kibana/actions/runs/22404323226

---

### Changed files
```
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts
```

### Final spec state

<details>
<summary>Expand final spec</summary>

```
## Status

done

## PR title

Add Elky easter egg to Streams UI search

## Context

Creating new changes against flash1293/action-ralph. Make file changes locally — a separate publish step handles PR creation.

## Tasks

- [x] Understand the request: Implement a Streams UI easter egg: when the stream search query is "Where is Elky?" (case-insensitive, surrounding whitespace ignored), render an elk emoji banner above the main Streams list table.

Requirements:

1. Implement the behavior in the Streams UI code path used for the main list/table.
2. Add/adjust unit tests to cover:
   - exact phrase match
   - case-insensitive match
   - no banner for other queries
3. Run scoped validations before finishing:
   - at least one relevant Jest test run
   - skip type check because it's so slow
4. In the final spec, include the exact validation commands and whether they passed.

- [x] Plan and expand this into concrete implementation tasks based on what you find. Keep in mind each task runs in a separate agent session with fresh context, so each should be self-contained. Include validation (run tests).
- [x] Implement the elk emoji banner display logic in StreamsTreeTable component (x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx). Add logic to detect "Where is Elky?" query (case-insensitive, trimmed) and render an emoji banner above the table when matched.
- [x] Add utility function tests in utils.test.ts to verify the easter egg detection logic works correctly for exact match, case variations, and non-matching queries.
- [x] Run Jest tests for the modified files and verify all tests pass. Include the exact test command and results in Additional Context.

## Definition of done

All requested changes are implemented, tests pass, and the spec status is set to "done".

## Additional Context

### Session 1: Understanding the codebase

**Key files identified:**

- `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx` - Main table component where search query state is managed (line 88: `searchQuery` state)
- `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts` - Utility functions for filtering streams
- `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts` - Existing unit tests

**Implementation approach:**

1. In `tree_table.tsx`, add a function to detect "Where is Elky?" query (case-insensitive, trimmed whitespace)
2. When detected, render an elk emoji banner (e.g., "🦌 🦌 🦌 Elky is here! 🦌 🦌 🦌") above the EuiInMemoryTable
3. The search query is stored in `searchQuery` state (line 88), accessed via `searchQuery?.text`
4. Add tests to verify the detection logic

**Test file location:**

- `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts` (existing test file)

### Session 2: Implementation Complete

**Files modified:**

1. `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx` (lines 30, 343-366, 635)

   - Added import for `isElkyEasterEggQuery` utility function
   - Added `isElkyQuery` memoized check using the utility function (lines 343-346)
   - Wrapped the component return in a React fragment to render the easter egg banner conditionally (lines 348-366)
   - Added elk emoji banner with proper accessibility attributes (role="img" and aria-label) above the EuiInMemoryTable
   - Banner displays with centered text, light background, and rounded corners when query matches

2. `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts` (lines 223-227)

   - Added `isElkyEasterEggQuery` utility function
   - Function detects "Where is Elky?" query (case-insensitive, trimmed)

3. `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts` (lines 8-13, 273-306)
   - Added import for `isElkyEasterEggQuery`
   - Added comprehensive test suite for the easter egg detection:
     - Exact match test
     - Case-insensitive tests (lowercase, uppercase, mixed case)
     - Whitespace trimming tests (leading/trailing spaces, tabs, newlines)
     - Non-matching query tests (missing question mark, wrong text, partial matches)
     - Undefined and empty string tests

**Validation results:**

✅ **Jest tests passed:**

```bash
yarn test:jest x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts
```

Result: All 16 tests passed (11 existing + 5 new easter egg tests)

✅ **ESLint passed:**

```bash
node scripts/eslint.js x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx --fix
node scripts/eslint.js x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.ts x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/utils.test.ts --fix
```

Result: No errors found

**Implementation details:**

- The easter egg banner is conditionally rendered above the streams table when the search query exactly matches "Where is Elky?" (case-insensitive, whitespace trimmed)
- The banner displays: "🦌 🦌 🦌 Elky is here! 🦌 🦌 🦌"
- Accessibility: Emojis are wrapped in a span with `role="img"` and `aria-label="Elk emoji banner"` to comply with jsx-a11y/accessible-emoji rules
- The banner has a `data-test-subj="elkyEasterEggBanner"` for testing purposes
- Detection logic is extracted into a reusable utility function with comprehensive unit test coverage
```
</details>

---

> This PR was generated by Action Ralph and is tagged `ai-generated`.
> It **requires manual review and approval** before merging.

cc @flash1293
