### PR TITLE
[Streams] Visual improvements for AI suggestions panel

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/review_suggestions_form/review_suggestions_form.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/data_management/stream_detail_routing/review_suggestions_form/review_suggestions_form.tsx
@@ -179,10 +179,17 @@ export function ReviewSuggestionsForm({
               })}
               aria-label={masterCheckboxLabel}
               data-test-subj="streamsAppMasterSuggestionCheckbox"
+              className={css`
+                margin-left: 16px;
+              `}
             />
             <EuiSpacer size="m" />
             {suggestions.map((partition, index) => (
-              <NestedView key={partition.name} last={index === suggestions.length - 1}>
+              <NestedView
+                key={partition.name}
+                last={index === suggestions.length - 1}
+                useDarkBorders
+              >
                 <SuggestedStreamPanel
                   definition={definition}
                   partition={partition}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/nested_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/nested_view/index.tsx
@@ -14,15 +14,18 @@ export function NestedView({
   last,
   first,
   isBeingDragged,
+  useDarkBorders = false,
 }: {
   children: React.ReactNode;
   last?: boolean;
   first?: boolean;
   isBeingDragged?: boolean;
+  useDarkBorders?: boolean;
 }) {
   const { euiTheme } = useEuiTheme();
 
-  const borderStyle = `${euiTheme.border.width.thin} solid ${euiTheme.colors.darkShade}`;
+  const borderColor = useDarkBorders ? euiTheme.colors.darkShade : euiTheme.border.color;
+  const borderStyle = `${euiTheme.border.width.thin} solid ${borderColor}`;
 
   return isBeingDragged ? (
     <>{children}</>


### PR DESCRIPTION
## Summary

Addresses review feedback from https://github.com/elastic/kibana/pull/251467#issuecomment-3965675308:

1. **"Select all" checkbox spacing**: Added `margin-left: 16px` to center the checkbox above the hierarchy lines below it (which also have 16px left margin)

2. **Configurable dark borders in NestedView**: Added `useDarkBorders` prop to `NestedView` component:
   - Defaults to `false` (uses standard `euiTheme.border.color`)
   - When `true`, uses `euiTheme.colors.darkShade` for better contrast on colored backgrounds
   - Only the suggestion panel (blue callout) uses `useDarkBorders={true}`
   - Other usages (routing rules, query streams, streams list tree) now use standard border colors

## Test plan
- Visual verification only (styling changes)
- Type check passes
- ESLint passes

Refs: https://github.com/elastic/kibana/pull/251467#issuecomment-3965675308

Made with [Cursor](https://cursor.com)