### PR TITLE
Add Elky easter egg to Streams UI search

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.test.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nProvider } from '@kbn/i18n-react';
+import { StreamsTreeTable } from './tree_table';
+import { useStreamsAppRouter } from '../../hooks/use_streams_app_router';
+import { useTimeRange } from '../../hooks/use_time_range';
+import { useTimefilter } from '../../hooks/use_timefilter';
+import { useStreamDocCountsFetch } from '../../hooks/use_streams_doc_counts_fetch';
+import { useStreamsTour } from '../streams_tour';
+
+jest.mock('../../hooks/use_streams_app_router');
+jest.mock('../../hooks/use_time_range');
+jest.mock('../../hooks/use_timefilter');
+jest.mock('../../hooks/use_streams_doc_counts_fetch');
+jest.mock('../streams_tour');
+jest.mock('../streams_app_search_bar', () => ({
+  StreamsAppSearchBar: () => <div data-test-subj="mockSearchBar">Search Bar</div>,
+}));
+
+const mockUseStreamsAppRouter = useStreamsAppRouter as jest.MockedFunction<
+  typeof useStreamsAppRouter
+>;
+const mockUseTimeRange = useTimeRange as jest.MockedFunction<typeof useTimeRange>;
+const mockUseTimefilter = useTimefilter as jest.MockedFunction<typeof useTimefilter>;
+const mockUseStreamDocCountsFetch = useStreamDocCountsFetch as jest.MockedFunction<
+  typeof useStreamDocCountsFetch
+>;
+const mockUseStreamsTour = useStreamsTour as jest.MockedFunction<typeof useStreamsTour>;
+
+// Helper to render with required providers
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(<I18nProvider>{ui}</I18nProvider>);
+};
+
+describe('StreamsTreeTable', () => {
+  const mockRouter = {
+    link: jest.fn((path: string, params: unknown) => `/mock${path}`),
+    push: jest.fn(),
+  };
+
+  const mockDocCountsFetch = {
+    docCount: Promise.resolve([]),
+    failedDocCount: Promise.resolve([]),
+    degradedDocCount: Promise.resolve([]),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseStreamsAppRouter.mockReturnValue(
+      mockRouter as unknown as ReturnType<typeof useStreamsAppRouter>
+    );
+    mockUseTimeRange.mockReturnValue({
+      rangeFrom: 'now-15m',
+      rangeTo: 'now',
+      setTimeRange: jest.fn(),
+    } as unknown as ReturnType<typeof useTimeRange>);
+    mockUseTimefilter.mockReturnValue({
+      timeState: { from: 'now-15m', to: 'now' },
+    } as unknown as ReturnType<typeof useTimefilter>);
+    mockUseStreamDocCountsFetch.mockReturnValue({
+      getStreamDocCounts: jest.fn().mockReturnValue(mockDocCountsFetch),
+      getStreamHistogram: jest.fn().mockReturnValue({
+        histogram: Promise.resolve([]),
+      }),
+    } as unknown as ReturnType<typeof useStreamDocCountsFetch>);
+    mockUseStreamsTour.mockReturnValue({
+      getStepPropsByStepId: jest.fn().mockReturnValue({}),
+    } as unknown as ReturnType<typeof useStreamsTour>);
+  });
+
+  describe('Elky easter egg', () => {
+    it('should display the easter egg banner when searching for "Where is Elky"', async () => {
+      const { container } = renderWithProviders(<StreamsTreeTable streams={[]} />);
+
+      // Get the search input
+      const searchInput = container.querySelector('input[type="search"]');
+      expect(searchInput).toBeInTheDocument();
+
+      // Type the easter egg query
+      await userEvent.type(searchInput!, 'Where is Elky');
+
+      // Wait for the banner to appear
+      await waitFor(() => {
+        expect(screen.getByTestId('elkyEasterEggBanner')).toBeInTheDocument();
+      });
+
+      // Verify banner content
+      expect(screen.getByText('🦌 Elky is here!')).toBeInTheDocument();
+    });
+
+    it('should display the easter egg banner with different casing variations', async () => {
+      const variations = ['where is elky', 'WHERE IS ELKY', 'WhErE iS eLkY', 'where is Elky'];
+
+      for (const query of variations) {
+        const { container, unmount } = renderWithProviders(<StreamsTreeTable streams={[]} />);
+
+        const searchInput = container.querySelector('input[type="search"]');
+        await userEvent.type(searchInput!, query);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('elkyEasterEggBanner')).toBeInTheDocument();
+        });
+
+        unmount();
+      }
+    });
+
+    it('should display the easter egg banner with surrounding whitespace', async () => {
+      const variations = ['  Where is Elky  ', '\tWhere is Elky\t', ' Where is Elky'];
+
+      for (const query of variations) {
+        const { container, unmount } = renderWithProviders(<StreamsTreeTable streams={[]} />);
+
+        const searchInput = container.querySelector('input[type="search"]');
+        await userEvent.type(searchInput!, query);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('elkyEasterEggBanner')).toBeInTheDocument();
+        });
+
+        unmount();
+      }
+    });
+
+    it('should NOT display the easter egg banner for partial matches', async () => {
+      const nonMatchingQueries = [
+        'Where is',
+        'is Elky',
+        'Where is Elky the elk',
+        'Tell me where is Elky',
+      ];
+
+      for (const query of nonMatchingQueries) {
+        const { container, unmount } = renderWithProviders(<StreamsTreeTable streams={[]} />);
+
+        const searchInput = container.querySelector('input[type="search"]');
+        await userEvent.type(searchInput!, query);
+
+        // Wait a bit to ensure no banner appears
+        await waitFor(
+          () => {
+            expect(screen.queryByTestId('elkyEasterEggBanner')).not.toBeInTheDocument();
+          },
+          { timeout: 500 }
+        );
+
+        unmount();
+      }
+    });
+
+    it('should NOT display the easter egg banner for empty search', async () => {
+      renderWithProviders(<StreamsTreeTable streams={[]} />);
+
+      // Wait to ensure no banner appears
+      await waitFor(
+        () => {
+          expect(screen.queryByTestId('elkyEasterEggBanner')).not.toBeInTheDocument();
+        },
+        { timeout: 500 }
+      );
+    });
+
+    it('should hide the easter egg banner when search query changes to non-matching text', async () => {
+      const { container } = renderWithProviders(<StreamsTreeTable streams={[]} />);
+
+      const searchInput = container.querySelector('input[type="search"]');
+
+      // First, show the easter egg
+      await userEvent.type(searchInput!, 'Where is Elky');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('elkyEasterEggBanner')).toBeInTheDocument();
+      });
+
+      // Clear and type different text
+      await userEvent.clear(searchInput!);
+      await userEvent.type(searchInput!, 'some other query');
+
+      // Wait for the banner to disappear
+      await waitFor(() => {
+        expect(screen.queryByTestId('elkyEasterEggBanner')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should display the banner above the streams table', async () => {
+      const { container } = renderWithProviders(<StreamsTreeTable streams={[]} />);
+
+      const searchInput = container.querySelector('input[type="search"]');
+      await userEvent.type(searchInput!, 'Where is Elky');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('elkyEasterEggBanner')).toBeInTheDocument();
+      });
+
+      const banner = screen.getByTestId('elkyEasterEggBanner');
+      const table = screen.getByTestId('streamsTable');
+
+      // Verify the banner appears before the table in the DOM by comparing positions
+      expect(banner.compareDocumentPosition(table)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -18,6 +18,7 @@ import {
   EuiIconTip,
   EuiButtonIcon,
   EuiTourStep,
+  EuiCallOut,
 } from '@elastic/eui';
 import { css } from '@emotion/css';
 import type { ListStreamDetail } from '@kbn/streams-plugin/server/routes/internal/streams/crud/route';
@@ -310,6 +311,12 @@ export function StreamsTreeTable({
 
   const streamsListStepProps = getStepPropsByStepId('streams_list');
 
+  // Easter egg: detect "Where is Elky" search query
+  const showElkyEasterEgg = React.useMemo(() => {
+    const queryText = searchQuery?.text?.trim().toLowerCase() ?? '';
+    return queryText === 'where is elky';
+  }, [searchQuery?.text]);
+
   const nameColumnHeader = (
     <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
       {shouldComposeTree(sortField) && hasExpandable && (
@@ -340,261 +347,284 @@ export function StreamsTreeTable({
   );
 
   return (
-    <EuiInMemoryTable<TableRow>
-      loading={loading}
-      data-test-subj="streamsTable"
-      columns={[
-        {
-          field: 'nameSortKey',
-          name: nameColumnHeader,
-          sortable: (row: TableRow) => row.rootNameSortKey,
-          dataType: 'string',
-          render: (_: unknown, item: TableRow) => {
-            // Only show expand/collapse if tree mode is active and has children
-            const treeMode = shouldComposeTree(sortField);
-            const hasChildren = !!item.children && item.children.length > 0;
-            const isCollapsed = collapsed.has(item.stream.name);
-            return (
-              <EuiFlexGroup
-                alignItems="center"
-                gutterSize="s"
-                responsive={false}
-                className={css`
-                  margin-left: ${item.level * parseInt(euiTheme.size.xl, 10)}px;
-                `}
-              >
-                {treeMode && item.children && hasChildren && (
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon
-                      type={isCollapsed ? 'arrowRight' : 'arrowDown'}
-                      color="text"
-                      size="m"
-                      data-test-subj={`${isCollapsed ? 'expand' : 'collapse'}Button-${
-                        item.stream.name
-                      }`}
-                      aria-label={
-                        isCollapsed
-                          ? i18n.translate(
-                              'xpack.streams.streamsTreeTable.collapsedNodeAriaLabel',
-                              {
-                                defaultMessage: 'Collapsed node with {childCount} children',
-                                values: { childCount: item.children.length },
-                              }
-                            )
-                          : i18n.translate('xpack.streams.streamsTreeTable.expandedNodeAriaLabel', {
-                              defaultMessage: 'Expanded node with {childCount} children',
-                              values: { childCount: item.children.length },
-                            })
-                      }
-                      onClick={(e: React.MouseEvent) => {
-                        handleToggleCollapse(item.stream.name);
-                      }}
-                      tabIndex={0}
-                      role="button"
-                      onKeyDown={(e: React.KeyboardEvent) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          handleToggleCollapse(item.stream.name);
+    <>
+      {showElkyEasterEgg && (
+        <EuiCallOut
+          title="🦌 Elky is here!"
+          color="primary"
+          iconType="heart"
+          data-test-subj="elkyEasterEggBanner"
+          style={{ marginBottom: '16px' }}
+        />
+      )}
+      <EuiInMemoryTable<TableRow>
+        loading={loading}
+        data-test-subj="streamsTable"
+        columns={[
+          {
+            field: 'nameSortKey',
+            name: nameColumnHeader,
+            sortable: (row: TableRow) => row.rootNameSortKey,
+            dataType: 'string',
+            render: (_: unknown, item: TableRow) => {
+              // Only show expand/collapse if tree mode is active and has children
+              const treeMode = shouldComposeTree(sortField);
+              const hasChildren = !!item.children && item.children.length > 0;
+              const isCollapsed = collapsed.has(item.stream.name);
+              return (
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="s"
+                  responsive={false}
+                  className={css`
+                    margin-left: ${item.level * parseInt(euiTheme.size.xl, 10)}px;
+                  `}
+                >
+                  {treeMode && item.children && hasChildren && (
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon
+                        type={isCollapsed ? 'arrowRight' : 'arrowDown'}
+                        color="text"
+                        size="m"
+                        data-test-subj={`${isCollapsed ? 'expand' : 'collapse'}Button-${
+                          item.stream.name
+                        }`}
+                        aria-label={
+                          isCollapsed
+                            ? i18n.translate(
+                                'xpack.streams.streamsTreeTable.collapsedNodeAriaLabel',
+                                {
+                                  defaultMessage: 'Collapsed node with {childCount} children',
+                                  values: { childCount: item.children.length },
+                                }
+                              )
+                            : i18n.translate(
+                                'xpack.streams.streamsTreeTable.expandedNodeAriaLabel',
+                                {
+                                  defaultMessage: 'Expanded node with {childCount} children',
+                                  values: { childCount: item.children.length },
+                                }
+                              )
                         }
-                      }}
-                      style={{ cursor: 'pointer' }}
-                    />
-                  </EuiFlexItem>
-                )}
-                {treeMode && !hasChildren && (
-                  <EuiFlexItem grow={false}>
-                    <EuiIcon type="empty" color="text" size="m" aria-hidden="true" />
-                  </EuiFlexItem>
-                )}
-                <EuiFlexGroup alignItems="center" gutterSize="s" responsive wrap>
-                  <EuiLink
-                    data-test-subj={`streamsNameLink-${item.stream.name}`}
-                    href={router.link('/{key}', {
-                      path: { key: item.stream.name },
-                      query: { rangeFrom, rangeTo },
-                    })}
-                    onClick={(e: React.MouseEvent) => {
-                      e.preventDefault();
-                      router.push('/{key}', {
+                        onClick={(e: React.MouseEvent) => {
+                          handleToggleCollapse(item.stream.name);
+                        }}
+                        tabIndex={0}
+                        role="button"
+                        onKeyDown={(e: React.KeyboardEvent) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            handleToggleCollapse(item.stream.name);
+                          }
+                        }}
+                        style={{ cursor: 'pointer' }}
+                      />
+                    </EuiFlexItem>
+                  )}
+                  {treeMode && !hasChildren && (
+                    <EuiFlexItem grow={false}>
+                      <EuiIcon type="empty" color="text" size="m" aria-hidden="true" />
+                    </EuiFlexItem>
+                  )}
+                  <EuiFlexGroup alignItems="center" gutterSize="s" responsive wrap>
+                    <EuiLink
+                      data-test-subj={`streamsNameLink-${item.stream.name}`}
+                      href={router.link('/{key}', {
                         path: { key: item.stream.name },
                         query: { rangeFrom, rangeTo },
-                      });
-                    }}
-                  >
-                    <EuiHighlight search={searchQuery?.text ?? ''}>{item.stream.name}</EuiHighlight>
-                  </EuiLink>
-                  {item.stream.name === LOGS_ROOT_STREAM_NAME && (
-                    <DeprecatedLogsBadge
-                      openFlyout={openFlyout}
-                      hasNewStreams={getLegacyLogsStatus(wiredStreamsStatus).hasNewStreams}
-                    />
-                  )}
-                  {Streams.QueryStream.Definition.is(item.stream) && <QueryStreamBadge />}
+                      })}
+                      onClick={(e: React.MouseEvent) => {
+                        e.preventDefault();
+                        router.push('/{key}', {
+                          path: { key: item.stream.name },
+                          query: { rangeFrom, rangeTo },
+                        });
+                      }}
+                    >
+                      <EuiHighlight search={searchQuery?.text ?? ''}>
+                        {item.stream.name}
+                      </EuiHighlight>
+                    </EuiLink>
+                    {item.stream.name === LOGS_ROOT_STREAM_NAME && (
+                      <DeprecatedLogsBadge
+                        openFlyout={openFlyout}
+                        hasNewStreams={getLegacyLogsStatus(wiredStreamsStatus).hasNewStreams}
+                      />
+                    )}
+                    {Streams.QueryStream.Definition.is(item.stream) && <QueryStreamBadge />}
+                  </EuiFlexGroup>
                 </EuiFlexGroup>
-              </EuiFlexGroup>
-            );
+              );
+            },
           },
-        },
-        {
-          field: 'documentsCount',
-          name: (
-            <EuiFlexGroup alignItems="center" gutterSize="s">
-              {DOCUMENTS_COLUMN_HEADER}
-              {!canReadFailureStore && (
-                <EuiIconTip
-                  content={FAILURE_STORE_PERMISSIONS_ERROR}
-                  type="warning"
-                  color="warning"
-                  size="s"
-                />
-              )}
-            </EuiFlexGroup>
-          ),
-          width: '180px',
-          sortable: docCountsLoaded ? (row: TableRow) => docsByStream[row.stream.name] ?? 0 : false,
-          align: 'right',
-          dataType: 'number',
-          render: (_: unknown, item: TableRow) =>
-            item.data_stream ? (
-              <DocumentsColumn
-                indexPattern={item.stream.name}
-                histogramQueryFetch={getStreamHistogram(item.stream.name)}
-                timeState={timeState}
-                numDataPoints={numDataPoints}
-              />
-            ) : null,
-        },
-        {
-          field: 'dataQuality',
-          name: (
-            <EuiFlexGroup alignItems="center" gutterSize="s">
-              {DATA_QUALITY_COLUMN_HEADER}
-              {!canReadFailureStore && (
-                <EuiIconTip
-                  content={FAILURE_STORE_PERMISSIONS_ERROR}
-                  type="warning"
-                  color="warning"
-                  size="s"
-                />
-              )}
-            </EuiFlexGroup>
-          ),
-          width: '150px',
-          sortable: qualityLoaded
-            ? (item: TableRow) => qualityRank[item.dataQuality as QualityIndicators]
-            : false,
-          dataType: 'string',
-          render: (_: unknown, item: TableRow) =>
-            item.data_stream ? (
-              <DataQualityColumn
-                streamName={item.stream.name}
-                quality={item.dataQuality as QualityIndicators}
-                isLoading={
-                  totalDocsResult.loading || failedDocsResult.loading || degradedDocsResult.loading
-                }
-              />
-            ) : (
-              '-'
+          {
+            field: 'documentsCount',
+            name: (
+              <EuiFlexGroup alignItems="center" gutterSize="s">
+                {DOCUMENTS_COLUMN_HEADER}
+                {!canReadFailureStore && (
+                  <EuiIconTip
+                    content={FAILURE_STORE_PERMISSIONS_ERROR}
+                    type="warning"
+                    color="warning"
+                    size="s"
+                  />
+                )}
+              </EuiFlexGroup>
             ),
-        },
-        {
-          field: 'retentionMs',
-          name: (
-            <span aria-label={RETENTION_COLUMN_HEADER_ARIA_LABEL}>{RETENTION_COLUMN_HEADER}</span>
+            width: '180px',
+            sortable: docCountsLoaded
+              ? (row: TableRow) => docsByStream[row.stream.name] ?? 0
+              : false,
+            align: 'right',
+            dataType: 'number',
+            render: (_: unknown, item: TableRow) =>
+              item.data_stream ? (
+                <DocumentsColumn
+                  indexPattern={item.stream.name}
+                  histogramQueryFetch={getStreamHistogram(item.stream.name)}
+                  timeState={timeState}
+                  numDataPoints={numDataPoints}
+                />
+              ) : null,
+          },
+          {
+            field: 'dataQuality',
+            name: (
+              <EuiFlexGroup alignItems="center" gutterSize="s">
+                {DATA_QUALITY_COLUMN_HEADER}
+                {!canReadFailureStore && (
+                  <EuiIconTip
+                    content={FAILURE_STORE_PERMISSIONS_ERROR}
+                    type="warning"
+                    color="warning"
+                    size="s"
+                  />
+                )}
+              </EuiFlexGroup>
+            ),
+            width: '150px',
+            sortable: qualityLoaded
+              ? (item: TableRow) => qualityRank[item.dataQuality as QualityIndicators]
+              : false,
+            dataType: 'string',
+            render: (_: unknown, item: TableRow) =>
+              item.data_stream ? (
+                <DataQualityColumn
+                  streamName={item.stream.name}
+                  quality={item.dataQuality as QualityIndicators}
+                  isLoading={
+                    totalDocsResult.loading ||
+                    failedDocsResult.loading ||
+                    degradedDocsResult.loading
+                  }
+                />
+              ) : (
+                '-'
+              ),
+          },
+          {
+            field: 'retentionMs',
+            name: (
+              <span aria-label={RETENTION_COLUMN_HEADER_ARIA_LABEL}>{RETENTION_COLUMN_HEADER}</span>
+            ),
+            align: 'left',
+            sortable: (row: TableRow) => row.rootRetentionMs,
+            dataType: 'number',
+            width: '220px',
+            render: (_: unknown, item: TableRow) => (
+              <RetentionColumn
+                lifecycle={item.effective_lifecycle!}
+                aria-label={i18n.translate(
+                  'xpack.streams.streamsTreeTable.retentionCellAriaLabel',
+                  {
+                    defaultMessage: 'Retention policy for {name}',
+                    values: { name: item.stream.name },
+                  }
+                )}
+                dataTestSubj={`retentionColumn-${item.stream.name}`}
+              />
+            ),
+          },
+          {
+            field: 'definition',
+            name: 'Actions',
+            width: '60px',
+            align: 'left',
+            sortable: false,
+            dataType: 'string',
+            render: (_: unknown, item: TableRow) => (
+              <DiscoverBadgeButton
+                hasDataStream={!!item.data_stream || Streams.QueryStream.Definition.is(item.stream)}
+                indexMode={item.data_stream?.index_mode}
+                stream={item.stream}
+              />
+            ),
+          },
+        ]}
+        itemId="name"
+        items={items}
+        sorting={sorting}
+        noItemsMessage={NO_STREAMS_MESSAGE}
+        onTableChange={handleTableChange}
+        pagination={{
+          initialPageSize: 25,
+          pageSizeOptions: [25, 50, 100],
+          pageIndex: pagination.pageIndex,
+          pageSize: pagination.pageSize,
+        }}
+        executeQueryOptions={{ enabled: false }}
+        search={{
+          query: searchQuery,
+          onChange: handleQueryChange,
+          box: {
+            incremental: true,
+            'aria-label': STREAMS_TABLE_SEARCH_ARIA_LABEL,
+          },
+          toolsRight: (
+            <div className={datePickerStyle}>
+              <StreamsAppSearchBar showDatePicker />
+            </div>
           ),
-          align: 'left',
-          sortable: (row: TableRow) => row.rootRetentionMs,
-          dataType: 'number',
-          width: '220px',
-          render: (_: unknown, item: TableRow) => (
-            <RetentionColumn
-              lifecycle={item.effective_lifecycle!}
-              aria-label={i18n.translate('xpack.streams.streamsTreeTable.retentionCellAriaLabel', {
-                defaultMessage: 'Retention policy for {name}',
-                values: { name: item.stream.name },
-              })}
-              dataTestSubj={`retentionColumn-${item.stream.name}`}
-            />
-          ),
-        },
-        {
-          field: 'definition',
-          name: 'Actions',
-          width: '60px',
-          align: 'left',
-          sortable: false,
-          dataType: 'string',
-          render: (_: unknown, item: TableRow) => (
-            <DiscoverBadgeButton
-              hasDataStream={!!item.data_stream || Streams.QueryStream.Definition.is(item.stream)}
-              indexMode={item.data_stream?.index_mode}
-              stream={item.stream}
-            />
-          ),
-        },
-      ]}
-      itemId="name"
-      items={items}
-      sorting={sorting}
-      noItemsMessage={NO_STREAMS_MESSAGE}
-      onTableChange={handleTableChange}
-      pagination={{
-        initialPageSize: 25,
-        pageSizeOptions: [25, 50, 100],
-        pageIndex: pagination.pageIndex,
-        pageSize: pagination.pageSize,
-      }}
-      executeQueryOptions={{ enabled: false }}
-      search={{
-        query: searchQuery,
-        onChange: handleQueryChange,
-        box: {
-          incremental: true,
-          'aria-label': STREAMS_TABLE_SEARCH_ARIA_LABEL,
-        },
-        toolsRight: (
-          <div className={datePickerStyle}>
-            <StreamsAppSearchBar showDatePicker />
-          </div>
-        ),
-        filters:
-          qualityLoaded && canReadFailureStore
-            ? [
-                {
-                  type: 'field_value_selection',
-                  name: i18n.translate('xpack.streams.streamsTreeTable.dataQualityFilter.label', {
-                    defaultMessage: 'Data quality',
-                  }),
-                  field: 'dataQuality',
-                  multiSelect: 'or',
-                  options: [
-                    {
-                      value: 'good',
-                      name: i18n.translate(
-                        'xpack.streams.streamsTreeTable.dataQualityFilter.goodLabel',
-                        { defaultMessage: 'Good' }
-                      ),
-                    },
-                    {
-                      value: 'degraded',
-                      name: i18n.translate(
-                        'xpack.streams.streamsTreeTable.dataQualityFilter.degradedLabel',
-                        { defaultMessage: 'Degraded' }
-                      ),
-                    },
-                    {
-                      value: 'poor',
-                      name: i18n.translate(
-                        'xpack.streams.streamsTreeTable.dataQualityFilter.poorLabel',
-                        { defaultMessage: 'Poor' }
-                      ),
-                    },
-                  ],
-                },
-              ]
-            : [],
-      }}
-      tableCaption={STREAMS_TABLE_CAPTION_ARIA_LABEL}
-    />
+          filters:
+            qualityLoaded && canReadFailureStore
+              ? [
+                  {
+                    type: 'field_value_selection',
+                    name: i18n.translate('xpack.streams.streamsTreeTable.dataQualityFilter.label', {
+                      defaultMessage: 'Data quality',
+                    }),
+                    field: 'dataQuality',
+                    multiSelect: 'or',
+                    options: [
+                      {
+                        value: 'good',
+                        name: i18n.translate(
+                          'xpack.streams.streamsTreeTable.dataQualityFilter.goodLabel',
+                          { defaultMessage: 'Good' }
+                        ),
+                      },
+                      {
+                        value: 'degraded',
+                        name: i18n.translate(
+                          'xpack.streams.streamsTreeTable.dataQualityFilter.degradedLabel',
+                          { defaultMessage: 'Degraded' }
+                        ),
+                      },
+                      {
+                        value: 'poor',
+                        name: i18n.translate(
+                          'xpack.streams.streamsTreeTable.dataQualityFilter.poorLabel',
+                          { defaultMessage: 'Poor' }
+                        ),
+                      },
+                    ],
+                  },
+                ]
+              : [],
+        }}
+        tableCaption={STREAMS_TABLE_CAPTION_ARIA_LABEL}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Add elk emoji banner easter egg when searching "Where is Elky"
- Banner appears above the Streams list table
- Search is case-insensitive with whitespace trimming

**Workflow run:** https://github.com/flash1293/kibana/actions/runs/22771153139

---

### Changed files
```
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.test.tsx
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
```

### Final spec state

<details>
<summary>Expand final spec</summary>

```
## Status

done

## PR title

Add Elky easter egg to Streams UI search

## PR summary

- Add elk emoji banner easter egg when searching "Where is Elky"
- Banner appears above the Streams list table
- Search is case-insensitive with whitespace trimming

## Context

Creating new changes against flash1293/action-ralph. Make file changes locally — a separate publish step handles PR creation.

## Tasks

- [x] Understand the request: Original issue description:
      We need to implement a Streams UI easter egg: when the stream search query is "Where is Elky" (case-insensitive, surrounding whitespace ignored), render an elk emoji banner above the main Streams list table.

Recent issue comments:

- @flash1293 (2026-03-06T13:04:33Z): Action Ralph has completed the task and opened a PR: https://github.com/flash1293/kibana/pull/22
- @flash1293 (2026-03-06T15:58:57Z): /action-ralph implement this

Task:
implement this

- [x] Plan and expand this into concrete implementation tasks based on what you find. Keep in mind each task runs in a separate agent session with fresh context, so each should be self-contained. Include validation (run tests). Always keep the self-review task as the very last task.
- [x] Implement the easter egg: Modify `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx` to detect when the search query is "Where is Elky" (case-insensitive, trimmed), and render an elk emoji banner above the table using EUI components. Create a useMemo hook to check the query, and conditionally render the banner between the header section and the EuiInMemoryTable. Test manually by running the Streams UI.
- [x] Add unit tests: Create or update tests for the easter egg logic in the tree_table component. Verify that the banner shows when query is "Where is Elky" (with various casing/whitespace variations), and that it doesn't show for other queries. Run jest tests with `yarn test:jest` for the touched test file.
- [x] Validate changes: Run `node scripts/check_changes.ts` to verify baseline checks pass. Run `node scripts/eslint.js` on touched files with `--fix`. Run scoped type-check with `yarn test:type_check --project` on the streams_app tsconfig. Document validation results.
- [x] Self-review: With fresh eyes, review ALL changes made during this spec. Run `git diff` to see every change, read through each file carefully, and evaluate: (1) are best practices followed, (2) is the code clean and idiomatic for the codebase, (3) are there any bugs, edge cases, or missed requirements, (4) is naming consistent and descriptive, (5) are there unnecessary changes or leftover debug code. Fix any issues found. If fixes are applied, re-run the relevant local checks (jest/lint/typecheck for touched files) to ensure nothing is broken. Document review findings in Additional Context.

## Definition of done

All requested changes are implemented, tests pass, self-review is completed with no outstanding issues, and the spec status is set to "done".

## Additional Context

### Planning session findings:

**Streams plugin structure:**

- Streams UI plugin: `@kbn/streams-app-plugin` at `x-pack/platform/plugins/shared/streams_app/`
- Main streams list component: `StreamsTreeTable` in `tree_table.tsx`

**Key files:**

- Main component: `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx`
- Search state at line 88: `const [searchQuery, setSearchQuery] = useState<Query | undefined>();`
- Search query text available as: `searchQuery?.text`
- Filtering logic at lines 177-181 already trims and lowercases the query

**Implementation approach:**

1. Add a useMemo hook to check if `searchQuery?.text?.trim().toLowerCase() === 'where is elky'`
2. Conditionally render an EUI banner (using `EuiCallOut` or `EuiPanel`) with elk emoji above the `EuiInMemoryTable` (currently at line 343)
3. The banner should appear between the header section and the table

**Test file location:**

- Look for existing tests in `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/` directory
- Create tests if none exist, or add to existing test file

### Implementation session findings:

**Easter egg implementation completed:**

- Added `EuiCallOut` import to EUI imports in tree_table.tsx:21
- Created `showElkyEasterEgg` useMemo hook at line 314-317 that:
  - Checks if `searchQuery?.text?.trim().toLowerCase() === 'where is elky'`
  - Returns true/false to control banner visibility
  - Depends on `searchQuery?.text` for proper reactivity
- Wrapped return statement in React fragment (`<>...</>`) at lines 349-618
- Conditionally rendered EuiCallOut banner at lines 350-357:
  - Title: "🦌 Elky is here!"
  - Color: primary
  - Icon: heart
  - Data test subject: `elkyEasterEggBanner` (for testing)
  - Bottom margin: 16px (spacing before table)
- Banner appears above `EuiInMemoryTable` when query matches

**Validation results:**

- ESLint: ✅ Passed (no errors found)
- Type check: ✅ Passed after 748.6 seconds (exit code 0)
  - Used background + poll pattern due to long execution time
  - Scoped to streams_app tsconfig as required

**Files modified:**

- `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx`

**Working test command for next session:**

```bash
yarn test:jest x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.test.tsx
```

### Unit tests session findings:

**Test file created:**

- Created new test file: `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.test.tsx`
- Test suite: `StreamsTreeTable > Elky easter egg`
- 7 test cases covering all easter egg requirements

**Test coverage:**

1. ✅ Should display banner when searching "Where is Elky" (exact match)
2. ✅ Should display banner with different casing variations (where is elky, WHERE IS ELKY, etc.)
3. ✅ Should display banner with surrounding whitespace variations (leading/trailing spaces, tabs)
4. ✅ Should NOT display banner for partial matches (Where is, is Elky, Where is Elky the elk, etc.)
5. ✅ Should NOT display banner for empty search
6. ✅ Should hide banner when search query changes to non-matching text
7. ✅ Should display banner above the streams table (DOM position verification)

**Mocking approach:**

- Mocked all required hooks: `useStreamsAppRouter`, `useTimeRange`, `useTimefilter`, `useStreamDocCountsFetch`, `useStreamsTour`
- Mocked `StreamsAppSearchBar` component to simplify rendering
- Used React Testing Library for user interactions and assertions
- Properly mocked `getStreamDocCounts` to return promises for doc counts

**Test execution results:**

- All 7 tests passed ✅
- Execution time: ~24 seconds
- No flaky tests observed
- Tests verify both positive cases (banner shows) and negative cases (banner hidden)

**Files created:**

- `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.test.tsx`

### Validation session findings:

**All validation checks passed successfully:**

1. ✅ `node scripts/check_changes.ts` - Baseline checks passed (no errors)
2. ✅ ESLint on touched source file - No errors found
   - File checked: `x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx`
3. ✅ Scoped type-check - Exit code 0 (completed in 18.4 seconds)
   - Project: `x-pack/platform/plugins/shared/streams_app/tsconfig.json`

**Validation approach:**

- Used background + poll pattern for type-check to handle long execution times
- All checks passed without requiring any fixes
- Previous implementation and test sessions produced clean, valid code

### Self-review session findings:

**Review scope:**

- Reviewed full git diff covering 2 files:
  1. `tree_table.tsx` (implementation)
  2. `tree_table.test.tsx` (test file)

**Code quality evaluation:**

1. ✅ **Best practices followed:**

   - Used React.useMemo for efficient computation with proper dependency array
   - Proper TypeScript typing (no `any` types after fixes)
   - React fragments used appropriately to avoid unnecessary wrapper divs
   - EUI components used correctly (`EuiCallOut` with proper props)
   - Clear, descriptive variable name: `showElkyEasterEgg`
   - Inline comment documenting the easter egg purpose

2. ✅ **Clean and idiomatic code:**

   - Implementation follows existing patterns in the file
   - Indentation and formatting consistent with surrounding code
   - No unnecessary changes to unrelated code
   - No leftover debug code, TODOs, or commented-out code
   - Proper nullish coalescing operator (`??`) for default values

3. ✅ **Correctness:**

   - Logic correctly implements case-insensitive, whitespace-trimmed comparison
   - Edge cases handled: empty search, partial matches, case variations, whitespace
   - Reactive to search query changes via useMemo dependency
   - Banner positioned correctly above table using React fragment
   - No unhandled edge cases identified

4. ✅ **Test coverage:**

   - 7 comprehensive test cases covering all requirements
   - Tests for positive cases (exact match, case variations, whitespace)
   - Tests for negative cases (partial matches, empty, query changes)
   - DOM position verification ensuring banner appears above table
   - Proper mocking strategy with React Testing Library
   - All tests passing consistently

5. ✅ **Naming and consistency:**
   - Variable name `showElkyEasterEgg` is clear and descriptive
   - Data test subject `elkyEasterEggBanner` follows kebab-case convention
   - Banner title "🦌 Elky is here!" is friendly and appropriate
   - Test descriptions are clear and descriptive

**Issues found and fixed:**

- **TypeScript lint errors:** Test file had 6 `@typescript-eslint/no-explicit-any` errors
  - Fixed by replacing `any` with `unknown` in type assertions
  - Used double assertion pattern: `as unknown as ReturnType<typeof hookName>`
  - Re-ran ESLint: ✅ All errors resolved
  - Re-ran Jest tests: ✅ All 7 tests still passing

**Final validation after fixes:**

- ESLint: ✅ No errors (both files)
- Jest: ✅ All 7 tests passing (23.4s execution time)
- Type-check: ✅ Already validated in previous session

**Summary:**

Self-review completed successfully. Found and fixed TypeScript lint errors in the test file (replaced `any` types with proper `unknown` assertions). Implementation is clean, correct, well-tested, and follows Kibana best practices. No outstanding issues. All requirements from the original spec have been met.
```
</details>

---

> This PR was generated by Action Ralph and is tagged `ai-generated`.
> It **requires manual review and approval** before merging.

cc @flash1293
