### PR TITLE
Add "Where is Elky" easter egg banner to Streams UI

### DIFF
--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_banner.test.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_banner.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ElkyBanner } from './elky_banner';
+
+describe('ElkyBanner', () => {
+  it('renders the banner when visible is true', () => {
+    render(<ElkyBanner visible={true} />);
+    const banner = screen.getByTestId('elkyBanner');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent('🦌 🦌 🦌');
+  });
+
+  it('does not render the banner when visible is false', () => {
+    render(<ElkyBanner visible={false} />);
+    const banner = screen.queryByTestId('elkyBanner');
+    expect(banner).not.toBeInTheDocument();
+  });
+
+  it('renders with correct styling and structure', () => {
+    render(<ElkyBanner visible={true} />);
+    const banner = screen.getByTestId('elkyBanner');
+    expect(banner).toHaveClass('euiCallOut');
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_banner.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_banner.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+interface ElkyBannerProps {
+  visible: boolean;
+}
+
+export function ElkyBanner({ visible }: ElkyBannerProps) {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <>
+      <EuiCallOut
+        title="🦌 🦌 🦌"
+        color="primary"
+        iconType="empty"
+        size="s"
+        data-test-subj="elkyBanner"
+        css={css`
+          text-align: center;
+          .euiCallOutHeader__title {
+            font-size: 48px;
+            line-height: 1;
+          }
+        `}
+      />
+      <EuiSpacer size="m" />
+    </>
+  );
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_detection.test.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_detection.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Query } from '@elastic/eui';
+import { isElkyQuery } from './elky_detection';
+
+describe('isElkyQuery', () => {
+  it('returns true for exact match "where is elky"', () => {
+    const query = { text: 'where is elky' } as Query;
+    expect(isElkyQuery(query)).toBe(true);
+  });
+
+  it('returns true for case-insensitive match "WHERE IS ELKY"', () => {
+    const query = { text: 'WHERE IS ELKY' } as Query;
+    expect(isElkyQuery(query)).toBe(true);
+  });
+
+  it('returns true for mixed case "WhErE iS eLkY"', () => {
+    const query = { text: 'WhErE iS eLkY' } as Query;
+    expect(isElkyQuery(query)).toBe(true);
+  });
+
+  it('returns true when query has leading whitespace', () => {
+    const query = { text: '  where is elky' } as Query;
+    expect(isElkyQuery(query)).toBe(true);
+  });
+
+  it('returns true when query has trailing whitespace', () => {
+    const query = { text: 'where is elky  ' } as Query;
+    expect(isElkyQuery(query)).toBe(true);
+  });
+
+  it('returns true when query has both leading and trailing whitespace', () => {
+    const query = { text: '   where is elky   ' } as Query;
+    expect(isElkyQuery(query)).toBe(true);
+  });
+
+  it('returns false for different query text', () => {
+    const query = { text: 'some other search' } as Query;
+    expect(isElkyQuery(query)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    const query = { text: '' } as Query;
+    expect(isElkyQuery(query)).toBe(false);
+  });
+
+  it('returns false for undefined query', () => {
+    expect(isElkyQuery(undefined)).toBe(false);
+  });
+
+  it('returns false for query without text property', () => {
+    const query = {} as Query;
+    expect(isElkyQuery(query)).toBe(false);
+  });
+
+  it('returns false for partial match "where is elk"', () => {
+    const query = { text: 'where is elk' } as Query;
+    expect(isElkyQuery(query)).toBe(false);
+  });
+
+  it('returns false for query with extra words', () => {
+    const query = { text: 'where is elky today' } as Query;
+    expect(isElkyQuery(query)).toBe(false);
+  });
+});

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_detection.ts
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_detection.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Query } from '@elastic/eui';
+
+/**
+ * Detects if a search query matches "Where is Elky" (case-insensitive, whitespace-trimmed)
+ */
+export function isElkyQuery(query: Query | undefined): boolean {
+  const queryText = query?.text?.trim().toLowerCase();
+  return queryText === 'where is elky';
+}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
@@ -34,6 +34,7 @@ import { StreamsListEmptyPrompt } from './streams_list_empty_prompt';
 import { StreamsSettingsFlyout } from './streams_settings_flyout';
 import { StreamsTreeTable } from './tree_table';
 import { LegacyLogsDeprecationCallout } from './legacy_logs_deprecation_callout';
+import { ElkyBanner } from './elky_banner';
 import { CreateQueryStreamFlyout } from '../query_streams/create_query_stream_flyout';
 import { getFormattedError } from '../../util/errors';
 
@@ -146,6 +147,7 @@ export function StreamListView() {
   const [isSettingsFlyoutOpen, setIsSettingsFlyoutOpen] = React.useState(false);
   const [isClassicStreamCreationFlyoutOpen, setIsClassicStreamCreationFlyoutOpen] =
     React.useState(false);
+  const [showElkyBanner, setShowElkyBanner] = React.useState(false);
 
   return (
     <>
@@ -239,12 +241,14 @@ export function StreamListView() {
               streamsStatus={wiredStreamsStatus}
               openFlyout={() => setIsSettingsFlyoutOpen(true)}
             />
+            <ElkyBanner visible={showElkyBanner} />
             <StreamsTreeTable
               loading={streamsListFetch.loading}
               streams={streamsListFetch.value?.streams}
               canReadFailureStore={streamsListFetch.value?.canReadFailureStore}
               wiredStreamsStatus={wiredStreamsStatus}
               openFlyout={() => setIsSettingsFlyoutOpen(true)}
+              onElkyQueryChange={setShowElkyBanner}
             />
           </>
         )}

--- a/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
+++ b/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { i18n } from '@kbn/i18n';
 import type { Direction, EuiSearchBarProps, CriteriaWithPagination, Query } from '@elastic/eui';
 import {
@@ -25,6 +25,7 @@ import type { QualityIndicators } from '@kbn/dataset-quality-plugin/common';
 import { Streams, LOGS_ROOT_STREAM_NAME } from '@kbn/streams-schema';
 import useAsync from 'react-use/lib/useAsync';
 import type { WiredStreamsStatus } from '@kbn/streams-plugin/public';
+import { isElkyQuery } from './elky_detection';
 import { useStreamsTour } from '../streams_tour';
 import type { TableRow, SortableField } from './utils';
 import {
@@ -72,12 +73,14 @@ export function StreamsTreeTable({
   canReadFailureStore = false,
   wiredStreamsStatus,
   openFlyout,
+  onElkyQueryChange,
 }: {
   streams?: ListStreamDetail[];
   canReadFailureStore?: boolean;
   loading?: boolean;
   wiredStreamsStatus?: WiredStreamsStatus;
   openFlyout?: () => void;
+  onElkyQueryChange?: (isElkyQuery: boolean) => void;
 }) {
   const router = useStreamsAppRouter();
   const { rangeFrom, rangeTo } = useTimeRange();
@@ -94,6 +97,11 @@ export function StreamsTreeTable({
     pageIndex: 0,
     pageSize: 25,
   });
+
+  // Detect "Where is Elky" query and notify parent
+  useEffect(() => {
+    onElkyQueryChange?.(isElkyQuery(searchQuery));
+  }, [searchQuery, onElkyQueryChange]);
 
   const numDataPoints = 25;
 


### PR DESCRIPTION
## Summary

- Add elk emoji banner that appears when searching "Where is Elky" (case-insensitive) in Streams list
- Banner displays above the main table, below existing callouts
- Includes unit tests for detection logic and component rendering

**Workflow run:** https://github.com/flash1293/kibana/actions/runs/22773399452

---

### Changed files
```
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_banner.test.tsx
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_banner.tsx
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_detection.test.ts
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_detection.ts
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx
x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx
```

### Final spec state

<details>
<summary>Expand final spec</summary>

```
## Status

done

## PR title

Add "Where is Elky" easter egg banner to Streams UI

## PR summary

- Add elk emoji banner that appears when searching "Where is Elky" (case-insensitive) in Streams list
- Banner displays above the main table, below existing callouts
- Includes unit tests for detection logic and component rendering

## Context

Creating new changes against flash1293/action-ralph. Make file changes locally — a separate publish step handles PR creation.

## Tasks

- [x] Understand the request: Original issue description:
      We need to implement a Streams UI easter egg: when the stream search query is "Where is Elky" (case-insensitive, surrounding whitespace ignored), render an elk emoji banner above the main Streams list table.

Recent issue comments:

- @flash1293 (2026-03-06T13:04:33Z): Action Ralph has completed the task and opened a PR: https://github.com/flash1293/kibana/pull/22
- @flash1293 (2026-03-06T15:58:57Z): /action-ralph implement this
- @flash1293 (2026-03-06T16:59:09Z): /action-ralph implement this

Task:
implement this

- [x] Plan and expand this into concrete implementation tasks based on what you find. Keep in mind each task runs in a separate agent session with fresh context, so each should be self-contained. Include validation (run tests). Always keep the self-review task as the very last task.
- [x] Implement the elk banner component: Create a new component `ElkyBanner` in `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/elky_banner.tsx` that displays an elk emoji banner with appropriate styling using EUI components (EuiCallOut or similar). The component should accept a `visible` prop to control display.
- [x] Add query detection logic to tree_table.tsx: In `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx`, add logic to detect when `searchQuery?.text?.trim().toLowerCase() === 'where is elky'` and pass this state to the parent component via callback or export the detection as a derived value.
- [x] Integrate banner into StreamListView: In `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx`, import and render the `ElkyBanner` component between the existing callouts (line 241) and the `StreamsTreeTable` (line 242). Pass the detection state from tree_table to control visibility.
- [x] Add unit tests for ElkyBanner component: Create test file `elky_banner.test.tsx` to verify the component renders correctly when visible and doesn't render when not visible.
- [x] Add unit test for query detection logic: Add tests to verify case-insensitive matching and whitespace trimming for the "Where is Elky" query detection.
- [x] Run validation: Execute `yarn test:jest` for the new test files, `node scripts/eslint.js` on touched files with --fix, and scoped `yarn test:type_check` for the streams_app plugin. Document results in Additional Context.
- [x] Self-review: With fresh eyes, review ALL changes made during this spec. Run `git diff` to see every change, read through each file carefully, and evaluate: (1) are best practices followed, (2) is the code clean and idiomatic for the codebase, (3) are there any bugs, edge cases, or missed requirements, (4) is naming consistent and descriptive, (5) are there unnecessary changes or leftover debug code. Fix any issues found. If fixes are applied, re-run the relevant local checks (jest/lint/typecheck for touched files) to ensure nothing is broken. Document review findings in Additional Context.

## Definition of done

All requested changes are implemented, tests pass, self-review is completed with no outstanding issues, and the spec status is set to "done".

## Additional Context

### Discovery Session 1: Understanding the codebase

- **Streams UI Plugin Location**: `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app`
- **Main List View**: `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/index.tsx`
  - Component: `StreamListView`
  - Renders callouts at lines 234-241, then `StreamsTreeTable` at lines 242-248
  - Perfect location to add elk banner: between line 241 and 242
- **Tree Table Component**: `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/tree_table.tsx`
  - Search query state: line 88 `const [searchQuery, setSearchQuery] = useState<Query | undefined>()`
  - Query type from `@elastic/eui` includes a `text` property with the search string
  - Used in table search prop at line 549
- **Existing Callout Components for Reference**:
  - `WelcomeTourCallout`: `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/streams_tour/welcome_tour_callout.tsx`
  - `LegacyLogsDeprecationCallout`: `/home/runner/work/kibana/kibana/x-pack/platform/plugins/shared/streams_app/public/components/stream_list_view/legacy_logs_deprecation_callout.tsx`

### Implementation Plan

1. Create `ElkyBanner` component using EUI components (likely `EuiCallOut` with custom content)
2. Detect query in `tree_table.tsx` by checking `searchQuery?.text?.trim().toLowerCase() === 'where is elky'`
3. Lift detection state up or pass via callback to make it available in `StreamListView`
4. Render banner conditionally in `StreamListView` between existing callouts and table
5. Add comprehensive unit tests
6. Run validation on all touched files

### Implementation Session 2: Elk Banner Implementation

**Files Created:**

- `elky_banner.tsx` (37 lines): Component using `EuiCallOut` with elk emojis, centered text, and custom CSS
- `elky_banner.test.tsx` (31 lines): Tests for visible/not visible states and component structure
- `elky_query_detection.test.tsx` (79 lines): Comprehensive tests for query detection logic covering case-insensitivity, whitespace trimming, edge cases

**Files Modified:**

- `tree_table.tsx`:
  - Added `useEffect` import
  - Added `onElkyQueryChange?: (isElkyQuery: boolean) => void` prop
  - Added `useEffect` hook to detect query and call callback when query changes
- `index.tsx`:
  - Added `ElkyBanner` import
  - Added `showElkyBanner` state
  - Rendered `ElkyBanner` between `LegacyLogsDeprecationCallout` and `StreamsTreeTable`
  - Passed `onElkyQueryChange={setShowElkyBanner}` to `StreamsTreeTable`

**Validation Results:**

- ✅ `elky_banner.test.tsx`: All 3 tests passed (renders when visible, doesn't render when not visible, correct styling)
- ✅ `elky_query_detection.test.tsx`: All 12 tests passed (case-insensitive, whitespace trimming, edge cases)
- ✅ ESLint: No errors found on all touched files
- ⏳ Type-check: Started but timed out after 2 minutes (expected for large project, will use background polling pattern if issues arise)

**Implementation Notes:**

- Used `EuiCallOut` with `iconType="empty"` to suppress default icon
- Banner displays three elk emojis (🦌 🦌 🦌) in 48px font size, centered
- Detection logic in `useEffect` with dependency on `searchQuery` and `onElkyQueryChange`
- Query detection handles: case-insensitivity, leading/trailing whitespace, undefined/empty queries
- Banner is positioned between existing callouts and table, maintains consistent spacing with `EuiSpacer`

### Self-Review Session: Code Quality Improvements

**Issues Found and Fixed:**

1. **Code Structure Issue**: Original implementation had an orphaned test file `elky_query_detection.test.tsx` that defined an `isElkyQuery` function (lines 13-16) which was never imported or used. The actual detection logic was inline in `tree_table.tsx`. This violated DRY principles and created confusion about which code was actually running in production.

   **Fix Applied**:

   - Extracted the detection logic into a dedicated utility file: `elky_detection.ts`
   - Created proper unit tests in `elky_detection.test.ts`
   - Updated `tree_table.tsx` to import and use `isElkyQuery()` instead of inline logic
   - Removed the orphaned test file

2. **Code Quality Improvements**:
   - Better separation of concerns: detection logic now lives in a testable utility function
   - Cleaner `useEffect` in tree_table: `onElkyQueryChange?.(isElkyQuery(searchQuery))` instead of inline logic
   - Tests now verify the actual function used in production

**Final Validation Results:**

- ✅ `elky_detection.test.ts`: All 12 tests passed (case-insensitive, whitespace trimming, edge cases)
- ✅ `elky_banner.test.tsx`: All 3 tests passed (renders when visible, doesn't render when not visible, correct styling)
- ✅ ESLint: No errors on any touched files
- ✅ Type-check: Completed successfully after 682 seconds (expected for plugin-level type-check)

**Files in Final Implementation:**

- Modified: `index.tsx`, `tree_table.tsx`
- New: `elky_banner.tsx`, `elky_banner.test.tsx`, `elky_detection.ts`, `elky_detection.test.ts`

**Review Summary:**

The code is now clean, follows Kibana best practices, and properly separates concerns. All tests pass, type-check passes, and linting passes. The implementation correctly handles all requirements: case-insensitive search, whitespace trimming, banner rendering, and proper integration with the existing UI structure. No bugs, edge cases, or unnecessary changes remain.
```
</details>

---

> This PR was generated by Action Ralph and is tagged `ai-generated`.
> It **requires manual review and approval** before merging.

cc @flash1293
